### PR TITLE
add support for webmention v0.2's canonical rel="webmention"

### DIFF
--- a/webmention.php
+++ b/webmention.php
@@ -263,9 +263,10 @@ function webmention_query_var($vars) {
 add_filter('query_vars', 'webmention_query_var');
 
 /**
- * adds the "http://webmention.org/" meta-tag
+ * adds the webmention link meta-tags
  */
 function webmention_add_header() {
+  echo '<link rel="webmention" href="'.site_url("?webmention=endpoint").'" />'."\n";
   echo '<link rel="http://webmention.org/" href="'.site_url("?webmention=endpoint").'" />'."\n";
 }
 add_action("wp_head", "webmention_add_header");
@@ -569,11 +570,11 @@ function discover_webmention_server_uri( $url ) {
   if ( $links = wp_remote_retrieve_header( $response, 'link' ) ) {
     if ( is_array($links) ) {
       foreach ($links as $link) {
-        if (preg_match("/<(.+)>;\s+rel\s?=\s?[\"\']?http:\/\/webmention.org\/?[\"\']?/i", $link, $result))
+        if (preg_match("/<(.+)>;\s+rel\s?=\s?[\"\']?(http:\/\/)?webmention(.org\/?)?[\"\']?/i", $link, $result))
           return $result[1];
       }
     } else {
-      if (preg_match("/<(.+)>;\s+rel\s?=\s?[\"\']?http:\/\/webmention.org\/?[\"\']?/i", $links, $result))
+      if (preg_match("/<(.+)>;\s+rel\s?=\s?[\"\']?(http:\/\/)?webmention(.org\/?)?[\"\']?/i", $links, $result))
         return $result[1];
     }
   }


### PR DESCRIPTION
retains backward compatibility with rel="http://webmention.org/"

the inspiration was trying to reply to one of tantek's posts, since tantek.com only has the rel="webmention" link.
