### PR TITLE
explicitly set comment_approved=1 so that comments aren't sometimes marked as spam

### DIFF
--- a/webmention.php
+++ b/webmention.php
@@ -165,8 +165,9 @@ class WebMentionPlugin {
     // change this if your theme can't handle the webmention comment type
     $comment_type = apply_filters('webmention_comment_type', 'webmention');
     $comment_parent = null;
+    $comment_approved = '1';
 
-    $commentdata = compact('comment_post_ID', 'comment_author', 'comment_author_url', 'comment_author_email', 'comment_content', 'comment_type', 'comment_parent');
+    $commentdata = compact('comment_post_ID', 'comment_author', 'comment_author_url', 'comment_author_email', 'comment_content', 'comment_type', 'comment_parent', 'comment_approved');
 
     // check dupes
     global $wpdb;


### PR DESCRIPTION
maybe helps (and maybe fixes) #14. @pfefferle, you know wordpress better than me, but i think this will work. it at least still works in my setup with akismet running.
