### PR TITLE
return 403 if pings are disabled, not 500

### DIFF
--- a/webmention.php
+++ b/webmention.php
@@ -179,7 +179,7 @@ class WebMentionPlugin {
 
     // check if pings are allowed
     if ( !pings_open($post_ID) ) {
-      status_header(500);
+      status_header(403);
       echo "Pings are disabled for this post";
       exit;
     }


### PR DESCRIPTION
500 means internal server error, which clients (e.g. bridgy) often interpret as transient and worth retrying. 403 means the server refuses to handle the request, which i think is what we want here.

thanks in advance!
