### PR TITLE
Add Expiring Token to Endpoint

### DIFF
--- a/webmention.php
+++ b/webmention.php
@@ -70,8 +70,8 @@ class WebMentionPlugin {
   }
 
   /**
-   * get the three valid endpoint codes. In the returned array,
-   * the first item -index 0- is the most correct
+   * generate a valid expire code. 
+   * Three possible values are valid at any one time, ticks: 0, 1, or 2
    * 
    * @return array
    */

--- a/webmention.php
+++ b/webmention.php
@@ -94,7 +94,8 @@ class WebMentionPlugin {
     // as above, always use the lgoged out token.
     $token = '';
 
-
+    // custom hash used rather than standard nonce to prevent session data polluting the
+    // web mention endpoint. The endpoint needs to remain the same for all users.
     $expire_code = wp_hash( $expire_code . '|' . $action . '|' . $uid . '|' . $token, 'nonce' );
     
     return $expire_code;

--- a/webmention.php
+++ b/webmention.php
@@ -78,7 +78,7 @@ class WebMentionPlugin {
   public static function expire_codes() {
     $action = 'web mention endpoint';
     $time_format = 'Y-m-d a';
-    $time_block = 12 * 60 * 60;
+    $time_block = DAY_IN_SECONDS / 2;
     $valid_codes = array(
       date( $time_format, time() ),
       date( $time_format, time() - $time_block ),

--- a/webmention.php
+++ b/webmention.php
@@ -129,9 +129,6 @@ class WebMentionPlugin {
       }
     }
 
-    $content = file_get_contents('php://input');
-    parse_str($content);
-
     // plain text header
     header('Content-Type: text/plain; charset=' . get_option('blog_charset'));
 
@@ -142,6 +139,8 @@ class WebMentionPlugin {
       exit;
     }
 
+    $content = file_get_contents('php://input');
+    parse_str($content);
 
     // check if source url is transmitted
     if (!isset($source)) {

--- a/webmention.php
+++ b/webmention.php
@@ -71,7 +71,7 @@ class WebMentionPlugin {
 
   /**
    * get the three valid endpoint codes. In the returned array,
-   * the middle item is the most correct
+   * the first item -index 0- is the most correct
    * 
    * @return array
    */
@@ -79,8 +79,8 @@ class WebMentionPlugin {
     $format = 'Y-m-d a';
     $time_block = 12 * 60 * 60;
     $valid_codes = array(
-      date( $format, time() - $time_block ),
       date( $format, time() ),
+      date( $format, time() - $time_block ),
       date( $format, time() + $time_block )
     );
     
@@ -107,7 +107,6 @@ class WebMentionPlugin {
     else {
       // check if the end point has expired
       $valid_endpoint_codes = WebMentionPlugin::expire_codes();
-      $endpoint_code = $valid_endpoint_codes[1];
       
       $supplied_code = get_query_var( 'webmention' );
       $is_valid = false;
@@ -115,6 +114,7 @@ class WebMentionPlugin {
       foreach ( $valid_endpoint_codes as $expire_code ) {
         if ( $supplied_code == $expire_code ) {
           $is_valid = true;
+          break;
         }
       }
  
@@ -598,7 +598,7 @@ class WebMentionPlugin {
   public static function html_header() {
     // backwards compatibility with v0.1
     $valid_endpoint_codes = WebMentionPlugin::expire_codes();
-    $endpoint_code = $valid_endpoint_codes[1];
+    $endpoint_code = $valid_endpoint_codes[0];
     echo '<link rel="http://webmention.org/" href="'.site_url("?webmention=" . $endpoint_code ).'" />'."\n";
     echo '<link rel="webmention" href="'.site_url("?webmention=" . $endpoint_code ).'" />'."\n";
   }
@@ -609,7 +609,7 @@ class WebMentionPlugin {
   public static function http_header() {
     // backwards compatibility with v0.1
     $valid_endpoint_codes = WebMentionPlugin::expire_codes();
-    $endpoint_code = $valid_endpoint_codes[1];
+    $endpoint_code = $valid_endpoint_codes[0];
     header('Link: <'.site_url("?webmention=" . $endpoint_code).'>; rel="http://webmention.org/"', false);
     header('Link: <'.site_url("?webmention=" . $endpoint_code).'>; rel="webmention"', false);
   }

--- a/webmention.php
+++ b/webmention.php
@@ -129,7 +129,9 @@ class WebMentionPlugin {
       }
  
       if ( false == $is_valid ) {
-        return;
+        status_header(400);
+        echo "invalid endpoint";
+        exit;
       }
     }
 

--- a/webmention.php
+++ b/webmention.php
@@ -127,12 +127,6 @@ class WebMentionPlugin {
           break;
         }
       }
- 
-      if ( false == $is_valid ) {
-        status_header(400);
-        echo "invalid endpoint";
-        exit;
-      }
     }
 
     $content = file_get_contents('php://input');
@@ -140,6 +134,14 @@ class WebMentionPlugin {
 
     // plain text header
     header('Content-Type: text/plain; charset=' . get_option('blog_charset'));
+
+    // fail if invalide endpoint
+    if ( false == $is_valid ) {
+      status_header(400);
+      echo "invalid endpoint";
+      exit;
+    }
+
 
     // check if source url is transmitted
     if (!isset($source)) {

--- a/webmention.php
+++ b/webmention.php
@@ -134,7 +134,7 @@ class WebMentionPlugin {
 
     // fail if invalide endpoint
     if ( false == $is_valid ) {
-      status_header(400);
+      status_header(403);
       echo "invalid endpoint";
       exit;
     }

--- a/webmention.php
+++ b/webmention.php
@@ -76,16 +76,26 @@ class WebMentionPlugin {
    * @return array
    */
   public static function expire_codes() {
-    $format = 'Y-m-d a';
+    $action = 'web mention endpoint';
+    $time_format = 'Y-m-d a';
     $time_block = 12 * 60 * 60;
     $valid_codes = array(
-      date( $format, time() ),
-      date( $format, time() - $time_block ),
-      date( $format, time() + $time_block )
+      date( $time_format, time() ),
+      date( $time_format, time() - $time_block ),
+      date( $time_format, time() - ( 2 * $time_block ) )
     );
     
+    // always use logged out user code, endpoint may be looked up by a logged in user
+    // while the web mention comes from a logged out user (using curl or similar)
+    $uid = 0;
+    $uid = apply_filters( 'nonce_user_logged_out', $uid, $action );
+    
+    // as above, always use the lgoged out token.
+    $token = '';
+
+
     foreach ( $valid_codes as $key => $expire_code ) {
-      $valid_codes[$key] = wp_hash( $expire_code, 'nonce' );
+      $valid_codes[$key] = wp_hash( $expire_code . '|' . $action . '|' . $uid . '|' . $token, 'nonce' );
     }
     
     return $valid_codes;

--- a/webmention.php
+++ b/webmention.php
@@ -78,7 +78,7 @@ class WebMentionPlugin {
   public static function expire_codes() {
     $action = 'web mention endpoint';
     $time_format = 'Y-m-d a';
-    $time_block = DAY_IN_SECONDS / 2;
+    $time_block = 12 * HOUR_IN_SECONDS;
     $valid_codes = array(
       date( $time_format, time() ),
       date( $time_format, time() - $time_block ),

--- a/webmention.php
+++ b/webmention.php
@@ -90,7 +90,6 @@ class WebMentionPlugin {
     // always use logged out user code, endpoint may be looked up by a logged in user
     // while the web mention comes from a logged out user (using curl or similar)
     $uid = 0;
-    $uid = apply_filters( 'nonce_user_logged_out', $uid, $action );
     
     // as above, always use the lgoged out token.
     $token = '';

--- a/webmention.php
+++ b/webmention.php
@@ -112,7 +112,7 @@ class WebMentionPlugin {
       $supplied_code = get_query_var( 'webmention' );
       $is_valid = false;
  
-      foreach ( $valid_codes as $expire_code ) {
+      foreach ( $valid_endpoint_codes as $expire_code ) {
         if ( $supplied_code == $expire_code ) {
           $is_valid = true;
         }

--- a/webmention.php
+++ b/webmention.php
@@ -122,7 +122,7 @@ class WebMentionPlugin {
       $is_valid = false;
  
       foreach ( $valid_endpoint_codes as $expire_code ) {
-        if ( $supplied_code == $expire_code ) {
+        if ( hash_equals( $expire_code, $supplied_code ) ) {
           $is_valid = true;
           break;
         }


### PR DESCRIPTION
Add a rolling token to the webmention endpoint. 

A new token is generated every twelve hours, the current and previous two tokens are valid at any one time.

Native WP nonces are out as they include the session and user IDs.

Fixes #39 