### PR TITLE
How to enable WebMentions without coding

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ It’s a modern alternative to Pingback and other forms of Linkback.
 
 ### How can I send WebMentions ###
 
+Activate sending webmentions by checking the "Attempt to notify any blogs linked to from the article" option on the Settings --> Discussion page in WordPress.
 You can use the `send_webmention($source, $target)` function and pass a source and a target or you can fire an action like `do_action('send_webmention', $source, $target)`.
 
 ### How can I handle Homepage-WebMentions ###

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,7 @@ It’s a modern alternative to Pingback and other forms of Linkback.
 
 = How can I send WebMentions =
 
+Activate sending webmentions by checking the "Attempt to notify any blogs linked to from the article" option on the Settings --> Discussion page in WordPress.
 You can use the `send_webmention($source, $target)` function and pass a source and a target or you can fire an action like `do_action('send_webmention', $source, $target)`.
 
 = How can I handle Homepage-WebMentions =


### PR DESCRIPTION
The current description didn't make it really clear to me that this was an option without coding stuff into the WordPress core or maybe to the WPCron (does that still exist btw? haven't worked with WP for years).