### PR TITLE
Comments sent via salmon are also dupes

### DIFF
--- a/webmention.php
+++ b/webmention.php
@@ -230,7 +230,14 @@ class WebMentionPlugin {
 		if ( ! empty( $comments ) ) {
 			$comment = $comments[0];
 		} else {
-			$comment = null;
+			$comments = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->comments INNER JOIN $wpdb->commentmeta USING (comme
+nt_ID) WHERE comment_post_ID = %d AND meta_key = '_crossposting_link' AND meta_value = %s", $comment_post_ID, htmlentities( $comment_author_url )
+ ) );
+			if ( ! empty( $comments ) ) {
+				$comment = $comments[0];
+			} else {
+				$comment = null;
+			}
 		}
 
 		// disable flood control


### PR DESCRIPTION
Or anyone else who can't use comment_author_url as the original link,
but can use a _crossposting_link meta value.