### PR TITLE
Replace Direct Calls to Database with WordPress Functions

### DIFF
--- a/class-webmention-receiver.php
+++ b/class-webmention-receiver.php
@@ -275,11 +275,11 @@ class Webmention_Receiver {
 	 * @return array|null              the dupe or null
 	 */
 	public static function check_dupes( $comment, $commentdata ) {
-		global $wpdb;
-
-		// check if comment is already set
-		$comments = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_author_url = %s", $commentdata['comment_post_ID'], htmlentities( $commentdata['comment_author_url'] ) ) );
-
+		$args = array(
+					'comment_post_ID' => $commentdata['comment_post_ID'],
+					'author_url' => htmlentities( commentdata['comment_author_url'] ),
+		);
+		$comments = get_comments( $args );
 		// check result
 		if ( ! empty( $comments ) ) {
 			error_log( print_r( $comments, true ) . PHP_EOL, 3, dirname( __FILE__ ) . '/log.txt' );
@@ -291,7 +291,12 @@ class Webmention_Receiver {
 		// or anyone else who can't use comment_author_url as the original link,
 		// but can use a _crossposting_link meta value.
 		// @link https://github.com/pfefferle/wordpress-salmon/blob/master/plugin.php#L192
-		$comments = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->comments INNER JOIN $wpdb->commentmeta USING (comment_ID) WHERE comment_post_ID = %d AND meta_key = '_crossposting_link' AND meta_value = %s", $commentdata['comment_post_ID'], htmlentities( $commentdata['comment_author_url'] ) ) );
+		$args = array(
+				'comment_post_ID' => commentdata['comment_post_ID'],
+				'meta_key' => '_crossposting_link',
+				'meta_value' => commentdata['comment_author_url'],
+		);
+		$comments = get_comments( $args );
 
 		// check result
 		if ( ! empty( $comments ) ) {

--- a/class-webmention-sender.php
+++ b/class-webmention-sender.php
@@ -179,17 +179,14 @@ class Webmention_Sender {
 	 * Do webmentions
 	 */
 	public static function do_webmentions() {
-		global $wpdb;
-
-		// get all posts that should be "mentioned"
-		$mentions = $wpdb->get_results( "SELECT ID, meta_id FROM {$wpdb->posts}, {$wpdb->postmeta} WHERE {$wpdb->posts}.ID = {$wpdb->postmeta}.post_id AND {$wpdb->postmeta}.meta_key = '_mentionme'" );
-
-		// iterate mentions
-		foreach ( $mentions as $mention ) {
-			delete_metadata_by_mid( 'post', $mention->meta_id );
-
-			// send them webmentions
-			self::send_webmentions( $mention->ID );
+		$mentions = get_posts( array( 'meta_key' => '_mentionme', 'post_type' => 'any', 'fields' => 'ids', 'nopaging' => true ) );
+		if ( empty( $mentions ) ) {
+			return;
+		}
+		foreach ( $mentions as $mention ) {  
+					delete_post_meta( $mention , '_mentionme' );
+					// send them Webmentions
+					self::send_webmentions( $mention );
 		}
 	}
 


### PR DESCRIPTION
This bumps the version requirement to 4.5, but it avoids any direct calls to the database.