### PR TITLE
Unify HTTP Arguments, Set Minimum Version, and Cleanup

### DIFF
--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -40,11 +40,11 @@ class Webmention_Receiver {
 		add_action( 'webmention_request', array( 'Webmention_Receiver', 'default_request_handler' ), 10, 3 );
 	}
 
-  /**
-   * Pre-Sets for HTTP API
-   *
-   * @return array
-   */
+	/**
+	* Pre-Sets for HTTP API
+	*
+	* @return array
+	*/
 	public static function http_args( ) {
 		global $wp_version;
 		$plugin_version = '2.6.0';
@@ -342,13 +342,13 @@ class Webmention_Receiver {
 
 
 
-	/** 
+	/**
 	 * Parse meta tags from source content
 	 * Based on the Press This Meta Parsing Code
 	 *
 	 * @param string $source_content Source Content
-	 * 
-	 * @return array meta tags 
+	 *
+	 * @return array meta tags
 	 */
 	public static function get_meta_tags( $source_content ) {
 		if ( ! $source_content ) {

--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -40,6 +40,24 @@ class Webmention_Receiver {
 		add_action( 'webmention_request', array( 'Webmention_Receiver', 'default_request_handler' ), 10, 3 );
 	}
 
+  /**
+   * Pre-Sets for HTTP API
+   *
+   * @return array
+   */
+	public static function http_args( ) {
+		global $wp_version;
+		$plugin_version = '2.6.0';
+		$user_agent = apply_filters( 'http_headers_useragent', 'Webmention-Plugin/' . $plugin_version . '(WordPress/' . $wp_version . ')' );
+		$args = array(
+				'timeout' => 10,
+				'limit_response_size' => 1048576,
+		    'redirection' => 20,
+				'user-agent' => $user_agent,
+		);
+		return $args;
+	}
+
 	/**
 	 * Adds some query vars
 	 *
@@ -87,7 +105,7 @@ class Webmention_Receiver {
 			echo '"target" is not on this site';
 		}
 
-		$response = wp_remote_get( $_POST['source'], array( 'timeout' => 100 ) );
+		$response = wp_remote_get( $_POST['source'], self::http_args() );
 
 		// check if source is accessible
 		if ( is_wp_error( $response ) ) {

--- a/includes/class-webmention-sender.php
+++ b/includes/class-webmention-sender.php
@@ -35,23 +35,23 @@ class Webmention_Sender {
 		add_action( 'publish_post', array( 'Webmention_Sender', 'publish_post_hook' ) );
 	}
 
-  /**
-   * Pre-Sets for HTTP API
-   *
-   * @return array
-   */
-  public static function http_args( ) {
-    global $wp_version;
-    $plugin_version = '2.6.0';
-    $user_agent = apply_filters( 'http_headers_useragent', 'Webmention-Plugin/' . $plugin_version . '(WordPress/' . $wp_version . ')' );
-    $args = array(
-        'timeout' => 10,
-        'limit_response_size' => 1048576,
-        'redirection' => 20,
-        'user-agent' => $user_agent,
-    );
+	/**
+	* Pre-Sets for HTTP API
+	*
+	* @return array
+	*/
+	public static function http_args( ) {
+		global $wp_version;
+		$plugin_version = '2.6.0';
+		$user_agent = apply_filters( 'http_headers_useragent', 'Webmention-Plugin/' . $plugin_version . '(WordPress/' . $wp_version . ')' );
+		$args = array(
+		'timeout' => 10,
+		'limit_response_size' => 1048576,
+		'redirection' => 20,
+		'user-agent' => $user_agent,
+		);
 		return $args;
-  }
+	}
 
 	/**
 	 * Marks the post as "no webmentions sent yet"

--- a/includes/class-webmention-sender.php
+++ b/includes/class-webmention-sender.php
@@ -35,6 +35,24 @@ class Webmention_Sender {
 		add_action( 'publish_post', array( 'Webmention_Sender', 'publish_post_hook' ) );
 	}
 
+  /**
+   * Pre-Sets for HTTP API
+   *
+   * @return array
+   */
+  public static function http_args( ) {
+    global $wp_version;
+    $plugin_version = '2.6.0';
+    $user_agent = apply_filters( 'http_headers_useragent', 'Webmention-Plugin/' . $plugin_version . '(WordPress/' . $wp_version . ')' );
+    $args = array(
+        'timeout' => 10,
+        'limit_response_size' => 1048576,
+        'redirection' => 20,
+        'user-agent' => $user_agent,
+    );
+		return $args;
+  }
+
 	/**
 	 * Marks the post as "no webmentions sent yet"
 	 *
@@ -75,10 +93,8 @@ class Webmention_Sender {
 		// if I can't find an endpoint, perhaps you can!
 		$webmention_server_url = apply_filters( 'webmention_server_url', $webmention_server_url, $target );
 
-		$args = array(
-			'body' => 'source=' . urlencode( $source ) . '&target=' . urlencode( $target ),
-			'timeout' => 100,
-		);
+		$args = self::http_args();
+		$args['body'] = 'source=' . urlencode( $source ) . '&target=' . urlencode( $target );
 
 		if ( $webmention_server_url ) {
 			$response = wp_remote_post( $webmention_server_url, $args );
@@ -216,7 +232,7 @@ class Webmention_Sender {
 			return false;
 		}
 
-		$response = wp_remote_head( $url, array( 'timeout' => 100, 'httpversion' => '1.0' ) );
+		$response = wp_remote_head( $url, self::http_args() );
 
 		if ( is_wp_error( $response ) ) {
 			return false;
@@ -243,7 +259,7 @@ class Webmention_Sender {
 		}
 
 		// now do a GET since we're going to look in the html headers (and we're sure its not a binary file)
-		$response = wp_remote_get( $url, array( 'timeout' => 100, 'httpversion' => '1.0' ) );
+		$response = wp_remote_get( $url, self::http_args() );
 
 		if ( is_wp_error( $response ) ) {
 			return false;

--- a/readme.md
+++ b/readme.md
@@ -2,9 +2,9 @@
 **Contributors:** pfefferle  
 **Donate link:** http://14101978.de  
 **Tags:** webmention, pingback, trackback, linkback  
-**Requires at least:** 2.7  
-**Tested up to:** 4.4  
-**Stable tag:** 2.5.0  
+**Requires at least:** 4.5  
+**Tested up to:** 4.5  
+**Stable tag:** 2.6.0  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 
@@ -61,6 +61,13 @@ If you want to add a more complex request handler, you should take a look at the
 ## Changelog ##
 
 Project maintined on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+### 2.6.0 ###
+
+* removed duplicate request for HTML via get_meta_tags
+* refactoring
+* limits to same domain
+
 
 ### 2.5.0 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: pfefferle
 Donate link: http://14101978.de
 Tags: webmention, pingback, trackback, linkback
-Requires at least: 2.7
-Tested up to: 4.4
-Stable tag: 2.5.0
+Requires at least: 4.5
+Tested up to: 4.5
+Stable tag: 2.6.0
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 
@@ -61,6 +61,13 @@ If you want to add a more complex request handler, you should take a look at the
 == Changelog ==
 
 Project maintined on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+= 2.6.0 = 
+
+* removed duplicate request for HTML via get_meta_tags
+* refactoring
+* limits to same domain
+
 
 = 2.5.0 =
 


### PR DESCRIPTION
HTTP requests now use the same arguments for consistency, started changelog, and updated README with requirement for 4.5.
