### PR TITLE
Target Before Source Verification and Related Changes

### DIFF
--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -61,7 +61,9 @@ class Webmention_Receiver {
 		// check if source url is transmitted
 		if ( ! isset( $_POST['source'] ) ) {
 			status_header( 400 );
-			echo '"source" 
+			echo '"source" is missing';
+			exit;
+		}
 
 		// check if target url is transmitted
 		if ( ! isset( $_POST['target'] ) ) {

--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -51,8 +51,6 @@ class Webmention_Receiver {
 	 * @uses do_action() Calls 'webmention_request' on the default request
 	 */
 	public static function parse_query( $wp ) {
-		global $wp_version;
-
 		// check if it is a webmention request or not
 		if ( ! array_key_exists( 'webmention', $wp->query_vars ) ) {
 			return;
@@ -63,9 +61,7 @@ class Webmention_Receiver {
 		// check if source url is transmitted
 		if ( ! isset( $_POST['source'] ) ) {
 			status_header( 400 );
-			echo '"source" is missing';
-			exit;
-		}
+			echo '"source" 
 
 		// check if target url is transmitted
 		if ( ! isset( $_POST['target'] ) ) {
@@ -155,6 +151,7 @@ class Webmention_Receiver {
 	 *	and trackback compatible
 	 */
 	public static function default_request_handler( $data ) {
+		global $wp_version;
 		$user_agent = apply_filters( 'http_headers_useragent', 'WordPress/' . $wp_version . '; ' . get_bloginfo( 'url' ) );
 		$args = array(
 			'timeout' => 100,

--- a/webmention.php
+++ b/webmention.php
@@ -26,7 +26,7 @@ class Webmention_Plugin {
 	/**
 	 * Initialize Webmention Plugin
 	 */
-	public function init() {
+	public static function init() {
 		require_once( dirname( __FILE__ ) . '/includes/functions.php' );
 
 		// initialize Webmention Sender


### PR DESCRIPTION
This swaps the target verification before the source. To assist in that, it starts creating the $commentdata array and passes that, as it will be needed anyway.

The default request handler is now responsible for source verification and content creation...which means it could be replaced with an async handler as needed.

'vouch' is now a parameter passed into the comment array, which allows for vouch testing support at the preprocess_comment level or a handler that will handle vouch to be used. 

To match changes made to pingbacks in WordPress, it now passes variables remote_source and remote_source original into the commentdata. This will allow a future update to Semantic Linkbacks that will avoid it having to pull the source an additional time. 

Also fixed an error in the latest refactoring that generated a strict standards warning because an init function didn't have static.

And, as the code is parsing meta tags, it will look for a title in the meta tags before parsing the title.

This time I did do some testing to make sure it worked as expected.