### PR TITLE
fix incompatibility with Ultimate Category Excluder plugin

### DIFF
--- a/includes/class-webmention-sender.php
+++ b/includes/class-webmention-sender.php
@@ -174,6 +174,12 @@ class Webmention_Sender {
 	 * Do webmentions
 	 */
 	public static function do_webmentions() {
+		// The Ultimate Category Excluder plugin filters get_posts to hide
+		// user-defined categories, but we're not displaying posts here, so
+		// temporarily disable it.
+		if ( function_exists( 'ksuce_exclude_categories' ) ) {
+			remove_filter( 'pre_get_posts', 'ksuce_exclude_categories' );
+		}
 		$mentions = get_posts(
 			array(
 				'meta_key' => '_mentionme',
@@ -184,6 +190,9 @@ class Webmention_Sender {
 				'nopaging' => true,
 			)
 		);
+		if ( function_exists( 'ksuce_exclude_categories' ) ) {
+			add_filter( 'pre_get_posts', 'ksuce_exclude_categories' );
+		}
 
 		if ( empty( $mentions ) ) {
 			return;

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ Project maintained on github at [pfefferle/wordpress-webmention](https://github.
 * Deprecation of webmention_title and webmention_content filters in favor of a single targeted webmention comment data filter.
 * webmention_post_send action now fires on all attempts to send a webmention instead of only successful ones. Allows for logging functions to be added.
 * Supports adding additional parameters when sending webmentions
+* Fix incompatibility with Ultimate Category Excluder plugin.
 
 ### 2.6.0 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -73,6 +73,7 @@ Project maintained on github at [pfefferle/wordpress-webmention](https://github.
 * Deprecation of webmention_title and webmention_content filters in favor of a single targeted webmention comment data filter.
 * webmention_post_send action now fires on all attempts to send a webmention instead of only successful ones. Allows for logging functions to be added.
 * Supports adding additional parameters when sending webmentions
+* Fix incompatibility with Ultimate Category Excluder plugin.
 
 = 2.6.0 =
 


### PR DESCRIPTION
fixes #98. the Ultimate Category Excluder plugin (https://wordpress.org/plugins/ultimate-category-excluder/) filters get_posts to hide user-defined categories, but we're not displaying posts here, so temporarily disable it.

this is a noop for users who don't have Ultimate Category Excluder installed.

cc @pfefferle, @dshanske