### PR TITLE
Take Advantage of 4.7

### DIFF
--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -206,14 +206,18 @@ class Webmention_Receiver {
 		}
 
 		// disable flood control
-		remove_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
+		remove_filter( 'wp_is_comment_flood', 'wp_check_comment_flood', 10 );
 		// update or save webmention
 		if ( empty( $commentdata['comment_ID'] ) ) {
 			// save comment
-			$commentdata['comment_ID'] = wp_new_comment( $commentdata );
+			$commentdata['comment_ID'] = wp_new_comment( $commentdata, true );
 		} else {
 			// save comment
 			wp_update_comment( $commentdata );
+		}
+
+		if ( is_wp_error( $commentdata['comment_ID'] ) ) {
+			return new WP_REST_Response( $commentdata['comment_ID'], 500 );
 		}
 
 		/**
@@ -227,7 +231,7 @@ class Webmention_Receiver {
 		do_action( 'webmention_post', $commentdata['comment_ID'], $commentdata );
 
 		// re-add flood control
-		add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
+		add_filter( 'wp_is_comment_flood', 'wp_check_comment_flood', 10, 5 );
 
 		// Return select data
 		$return = array(

--- a/webmention.php
+++ b/webmention.php
@@ -57,11 +57,26 @@ class Webmention_Plugin {
 	 * Register Webmention admin settings.
 	 */
 	public static function admin_register_settings() {
-		register_setting( 'discussion', 'webmention_disable_selfpings_same_url' );
-		register_setting( 'discussion', 'webmention_disable_selfpings_same_domain' );
-		register_setting( 'discussion', 'webmention_show_comment_form' );
+		register_setting( 'discussion', 'webmention_disable_selfpings_same_url', array(
+			'type' => 'boolean',
+			'description' => 'Disable Self Webmentions on the Same URL',
+			'show_in_rest' => 'true',
+			'default' => 1
+		) );
+		register_setting( 'discussion', 'webmention_disable_selfpings_same_domain', array(
+			'type' => 'boolean',
+			'description' => 'Disable Self Webmentions on the Same Domain',
+			'show_in_rest' => 'true',
+			'default' => 0 
+		) );
+		register_setting( 'discussion', 'webmention_show_comment_form', array(
+			'type' => 'boolean',
+			'description' => 'Show Webmention Comment Form',
+			'show_in_rest' => 'true',
+			'default' => 1 
+		) );
 
-		add_settings_field( 'webmention_disucssion_settings', __( 'Webmention Settings', 'webmention' ), array( 'Webmention_Plugin', 'discussion_settings' ), 'discussion', 'default' );
+		add_settings_field( 'webmention_discussion_settings', __( 'Webmention Settings', 'webmention' ), array( 'Webmention_Plugin', 'discussion_settings' ), 'discussion', 'default' );
 	}
 
 	/**


### PR DESCRIPTION
This changes to the new flood filter and supports register_settings for default. 

It also instructs a WP_Error return instead of wp_die as a return of a WP_Error indicates that we aren't handling things correctly. But this can't be addressed if the code dies.

I'd like it if there was a way to handle flooding, being as webmentions should be protected against it, but that doesn't work with the filter we have. 