### PR TITLE
Improve Exotic Mentions Support

### DIFF
--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -128,9 +128,8 @@ class Webmention_Receiver {
 			return new WP_Error( 'target', __( 'Target is not on this domain', 'webmention' ), array( 'status' => 400 ) );
 		}
 
-		$comment_post_id = url_to_postid( $target );
-		// add some kind of a "default" id to add linkbacks to a specific post/page
-		$comment_post_id = apply_filters( 'webmention_post_id', $comment_post_id, $target );
+		// Returns a post id for a webmention target
+		$comment_post_id = webmention_post_id( $target );
 		if ( url_to_postid( $source ) === $comment_post_id ) {
 			return new WP_Error( 'source_equals_target', __( 'Target and source cannot direct to the same resource', 'webmention' ), array( 'status' => 400 ) );
 		}
@@ -478,7 +477,8 @@ class Webmention_Receiver {
 	 * The Webmention autodicovery meta-tags
 	 */
 	public static function html_header() {
-		if ( is_singular() && pings_open() ) {
+		$open = ( is_singular() && pings_open() ) ? true : mentions_open();
+		if ( $open ) {
 			// backwards compatibility with v0.1
 			printf( '<link rel="http://webmention.org/" href="%s" />' . PHP_EOL, get_webmention_endpoint() );
 			printf( '<link rel="webmention" href="%s" />' . PHP_EOL, get_webmention_endpoint() );
@@ -489,7 +489,8 @@ class Webmention_Receiver {
 	 * The Webmention autodicovery http-header
 	 */
 	public static function http_header() {
-		if ( is_singular() && pings_open() ) {
+		$open = ( is_singular() && pings_open() ) ? true : mentions_open();
+		if ( $open ) {
 			// backwards compatibility with v0.1
 			header( sprintf( 'Link: <%s>; rel="http://webmention.org/"', get_webmention_endpoint() ), false );
 			header( sprintf( 'Link: <%s>; rel="webmention"', get_webmention_endpoint() ), false );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -57,6 +57,37 @@ function get_webmention_process_type() {
 	return apply_filters( 'webmention_process_type', WEBMENTION_PROCESS_TYPE );
 }
 
+/**
+ * Are mentions open for a URL?
+ *
+ * @param string $url The URL.
+ * @return boolean
+ */
+function mentions_open( $url = null ) {
+	if ( ! $url ) {
+		$url = esc_url( set_url_scheme( 'http://' . wp_parse_url( home_url(), PHP_URL_HOST ) . wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
+	}
+	/**
+	 * Filters whether the current URL is open for mentions.
+	 *
+	 *
+	 * @param bool        $open    Whether the current URL is open for mentions.
+	 * @param string $url The current URL.
+	 */
+	return apply_filters( 'mentions_open', false, $url );
+}
+
+/**
+ * Return the post_id for a URL filtered for webmentions.
+ * Allows redirecting to another id to add linkbacks to the home page or archive page or taxonomy page.
+ *
+ * @param string $url URL
+ * @param int Return 0 if no post ID found or a post ID
+ */
+function webmention_post_id( $url ) {
+	return apply_filters( 'webmention_post_id', url_to_postid( $url ), $url );
+}
+
 if ( ! function_exists( 'wp_get_meta_tags' ) ) :
 	/**
 	 * Parse meta tags from source content

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ You can use the `send_webmention($source, $target)` function and pass a source a
 
 Webmentions should be allowed on all URLs of a blog. The plugin currently supports only Webmentions on
 posts or pages, but it is very simple to add support for other types like homepages or archive pages.
-The easiest way is to provide some kind of a default post/page to show collect all mentions that are no
+The easiest way is to provide some kind of a default post/page to show collect all mentions that are not
 comments on a post or a page. The plugin provides a simple filter for that:
 
     function handle_exotic_webmentions($id, $target) {
@@ -78,6 +78,8 @@ Project maintained on github at [pfefferle/wordpress-webmention](https://github.
 * webmention_post_send action now fires on all attempts to send a webmention instead of only successful ones. Allows for logging functions to be added.
 * Supports adding additional parameters when sending webmentions
 * Fix incompatibility with Ultimate Category Excluder plugin.
+* webmention_post_id now is a function as well as a filter
+* New function and filter mentions_open that checks a URL for open mentions.
 
 ### 2.6.0 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -49,7 +49,7 @@ You can use the `send_webmention($source, $target)` function and pass a source a
 
 Webmentions should be allowed on all URLs of a blog. The plugin currently supports only Webmentions on
 posts or pages, but it is very simple to add support for other types like homepages or archive pages.
-The easiest way is to provide some kind of a default post/page to show collect all mentions that are no
+The easiest way is to provide some kind of a default post/page to show collect all mentions that are not
 comments on a post or a page. The plugin provides a simple filter for that:
 
     function handle_exotic_webmentions($id, $target) {
@@ -76,6 +76,8 @@ Project maintained on github at [pfefferle/wordpress-webmention](https://github.
 * webmention_post_send action now fires on all attempts to send a webmention instead of only successful ones. Allows for logging functions to be added.
 * Supports adding additional parameters when sending webmentions
 * Fix incompatibility with Ultimate Category Excluder plugin.
+* webmention_post_id now is a function as well as a filter
+* New function and filter mentions_open that checks a URL for open mentions.
 
 = 2.6.0 =
 


### PR DESCRIPTION
This makes it a bit easier for webmentions of archives, taxonomy, and home pages to be redirected to a specific post_id.

It moves 'webmention_post_id' to a global function so it can be retrieved outside of the receiver transaction. It adds a second function and filter, 'mentions_open' to determine if a URL is to be considered 'open' for these URLs to add the headers. 

