### PR TITLE
Webmention Supports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ php:
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
-  - WP_VERSION=4.4 WP_MULTISITE=0
-  - WP_VERSION=4.5 WP_MULTISITE=0
 
 matrix:
   include:

--- a/includes/class-webmention-sender.php
+++ b/includes/class-webmention-sender.php
@@ -15,9 +15,11 @@ class Webmention_Sender {
 
 		// run webmentions before the other pinging stuff
 		add_action( 'do_pings', array( 'Webmention_Sender', 'do_webmentions' ), 5, 1 );
-
-		add_action( 'publish_post', array( 'Webmention_Sender', 'publish_hook' ) );
-		add_action( 'publish_page', array( 'Webmention_Sender', 'publish_hook' ) );
+		// Send Webmentions from Every Type that Declared Webmention Support
+		$post_types = get_post_types_by_support( 'webmentions' );
+		foreach ( $post_types as $post_type ) {
+			add_action( 'publish_' . $post_type, array( 'Webmention_Sender', 'publish_hook' ) );
+		}
 	}
 
 	/**
@@ -181,9 +183,7 @@ class Webmention_Sender {
 		$mentions = get_posts(
 			array(
 				'meta_key' => '_mentionme',
-				'post_type' => get_post_types(
-					array( 'public' => true )
-				),
+				'post_type' => get_post_types_by_support( 'webmentions' ),
 				'fields' => 'ids',
 				'nopaging' => true,
 			)

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,9 @@ When you link to a website, you can send it a Webmention to notify it. If it sup
 
 ### That Sounds Like a Pingback or a Trackback ###
 
-Webmention is an update/replacement for Pingback or Trackback. Unlike the older protocols, the specification is recommended by the W3C as well as an active community of individuals using it on their sites.
+Webmention is an update/replacement for Pingback or Trackback. Unlike the older protocols, the
+specification is recommended by the W3C as well as an active community of individuals using
+it on their sites.
 
 ### How can I send and receive Webmentions? ###
 
@@ -37,8 +39,12 @@ On the Settings --> Discussion Page in WordPress:
 You can use the `send_webmention($source, $target)` function and pass a source and a target or you can fire an action like `do_action('send_webmention', $source, $target)`.
 
 [vimeo https://vimeo.com/85217592]
-
 -- Video by [Andy Sylvester](http://andysylvester.com/2014/01/27/working-with-webmention-video/)
+
+### How do I support Webmentions for my custom post type? ###
+
+When declaring your custom post type, add post type support for webmentions by either including it in your register_post_type entry or adding it later using add_post_type_support. This
+will also add support for receiving pingbacks and trackbacks as WordPress cannot currently distinguish between different linkback types.
 
 ### How can I handle Webmentions to my Homepage or Archive Pages? ###
 
@@ -67,6 +73,10 @@ The URL for the webmention endpoint, which you can view in the source of your pa
 ## Changelog ##
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+### 3.1.2 ###
+* Enable option for page support
+* Allow custom post types to declare support for webmentions as a feature which will enable pings.
 
 ### 3.1.1 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,11 @@ You can use the `send_webmention($source, $target)` function and pass a source a
 [vimeo https://vimeo.com/85217592]
 -- Video by [Andy Sylvester](http://andysylvester.com/2014/01/27/working-with-webmention-video/)
 
+= How do I support Webmentions for my custom post type? =
+
+When declaring your custom post type, add post type support for webmentions by either including it in your register_post_type entry or adding it later using add_post_type_support. This
+will also add support for receiving pingbacks and trackbacks as WordPress cannot currently distinguish between different linkback types.
+
 = How can I handle Webmentions to my Homepage or Archive Pages? =
 
 Webmentions should be allowed on all URLs of a blog. The plugin currently supports only Webmentions on
@@ -66,6 +71,10 @@ The URL for the webmention endpoint, which you can view in the source of your pa
 == Changelog ==
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+= 3.1.2 =
+* Enable option for page support
+* Allow custom post types to declare support for webmentions as a feature which will enable pings.
 
 = 3.1.1 =
 

--- a/templates/webmention-discussion-settings.php
+++ b/templates/webmention-discussion-settings.php
@@ -15,6 +15,14 @@
 
 	<br />
 
+	<label for="webmention_support_pages">
+		<input type="checkbox" name="webmention_support_pages" id="webmention_support_pages" value="1" <?php
+			echo checked( true, get_option( 'webmention_support_pages' ) );  ?> />
+		<?php _e( 'Enable Webmention Support for Pages', 'webmention' ) ?>
+	</label>
+
+	<br />
+
 	<label for="webmention_show_comment_form">
 		<input type="checkbox" name="webmention_show_comment_form" id="webmention_show_comment_form" value="1" <?php
 			echo checked( true, get_option( 'webmention_show_comment_form' ) );  ?> />

--- a/webmention.php
+++ b/webmention.php
@@ -35,9 +35,9 @@ class Webmention_Plugin {
 	public static function init() {
 		// Add a new feature type to posts for webmentions
 		add_post_type_support( 'post', 'webmentions' );
-		//	if ( 1 == get_option( 'webmention_support_pages' ) ) {
-			add_post_type_support( 'page', array( 'webmentions' ) );
-		//	}
+		if ( 1 == get_option( 'webmention_support_pages' ) ) {
+			add_post_type_support( 'page', 'webmentions' );
+		}
 		if ( WP_DEBUG ) {
 			require_once( dirname( __FILE__ ) . '/includes/debug.php' );
 		}


### PR DESCRIPTION
This PR adds a post type support feature called 'webmentions' which is automatically added to type 'post', added if a setting is set to 'page', and would require any custom post types to add or note during declaration.

This setting will open or close ping status by default. The sending of webmentions is now limited to post types that support this setting.

This allows a much clearer way to declare support for webmentions with custom post types and can be used to send/receive them. It also removes the issue created when WordPress disabled ping status support by default for pages and post types that didn't declare trackbacks support.

Because the logic of how support is maintained is now handled by the Webmentions plugin, if we decide to, in future, not rely on ping_status to determine webmention status...we can switch without requiring any changes outside the plugin.