### PR TITLE
Support Creation Time and Webmention Source Storage

### DIFF
--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -32,6 +32,9 @@ class Webmention_Receiver {
 		// Save Fragments
 		add_filter( 'preprocess_comment', array( 'Webmention_Receiver', 'save_fragment' ), 9, 1 );
 
+		// Save Original Creation Time in GMT
+		add_filter( 'preprocess_comment', array( 'Webmention_Receiver', 'save_original_time' ), 9, 1 );
+
 		// Allow for avatars on webmention comment types
 		add_filter( 'get_avatar_comment_types', array( 'Webmention_Receiver', 'get_avatar_comment_types' ) );
 		self::register_meta();
@@ -55,6 +58,15 @@ class Webmention_Receiver {
 			'show_in_rest' => true,
 		);
 		register_meta( 'comment', 'webmention_target_fragment', $args );
+		// Purpose of this is to store the original time as there is no modified time in the comment table.
+		$args = array(
+			'type' => 'string',
+			'description' => 'Original Creation Time for the Webmention (GMT)',
+			'single' => true,
+			'show_in_rest' => true,
+		);
+		register_meta( 'comment', 'webmention_creation_time', $args );
+
 	}
 
 	/**
@@ -516,6 +528,23 @@ class Webmention_Receiver {
 		$commentdata['comment_meta']['webmention_target_url'] = $commentdata['target'];
 		return $commentdata;
 	}
+
+	/** 
+	 * Save Original Time
+	 * @param array $commentdata the comment-data
+	 *
+	 * @return array with added meta field
+	 */
+	public static function save_original_time( $commentdata ) {
+		if ( ! isset( $commentdata['comment_meta'] ) ) {
+			$commentdata['comment_meta'] = array();
+		}
+		// Save in GMT
+		$commentdata['comment_meta']['webmention_creation_time'] = current_time( mysql, true );
+		return $commentdata;
+	}
+
+
 
 	/**
 	 * Marks the post as "no webmentions sent yet"

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 **Tags:** webmention, pingback, trackback, linkback, indieweb  
 **Requires at least:** 4.7  
 **Tested up to:** 4.7.3  
-**Stable tag:** 3.1.1  
+**Stable tag:** 3.1.2  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 
@@ -77,6 +77,10 @@ Project and support maintained on github at [pfefferle/wordpress-webmention](htt
 ### 3.1.2 ###
 * Enable option for page support
 * Allow custom post types to declare support for webmentions as a feature which will enable pings.
+* Remove new meta properties from being added during preprocessing as these are added after Semantic Linkbacks Enhancement. 
+* Move new meta properties to being built into webmention code
+* Store webmention source in comment meta but fall back to checking `comment_author_url` if not set.
+* Store webmention creation time in comment meta as comment time is overridden by Semantic Linkbacks allowing to determine if a comment has been modified.
 
 ### 3.1.1 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://14101978.de
 Tags: webmention, pingback, trackback, linkback, indieweb
 Requires at least: 4.7
 Tested up to: 4.7.3
-Stable tag: 3.1.1
+Stable tag: 3.1.2
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 
@@ -75,6 +75,10 @@ Project and support maintained on github at [pfefferle/wordpress-webmention](htt
 = 3.1.2 =
 * Enable option for page support
 * Allow custom post types to declare support for webmentions as a feature which will enable pings.
+* Remove new meta properties from being added during preprocessing as these are added after Semantic Linkbacks Enhancement. 
+* Move new meta properties to being built into webmention code
+* Store webmention source in comment meta but fall back to checking `comment_author_url` if not set.
+* Store webmention creation time in comment meta as comment time is overridden by Semantic Linkbacks allowing to determine if a comment has been modified.
 
 = 3.1.1 =
 

--- a/webmention.php
+++ b/webmention.php
@@ -5,7 +5,7 @@
  * Description: Webmention support for WordPress posts
  * Author: pfefferle
  * Author URI: http://notiz.blog/
- * Version: 3.1.1
+ * Version: 3.1.2
  * License: MIT
  * License URI: http://opensource.org/licenses/MIT
  * Text Domain: webmention


### PR DESCRIPTION
This is to support storing webmention source and creation time in meta. 

The reasoning is that creation time is overwritten by Semantic Linkbacks and allows for the original time to be compared to the modified time, which is not stored in the comment table.

The source is stored, like pingbacks, in the author_url, which results in duplication of purpose, especially in Semantic Linkbacks. The code will still look at the comment_author_url if there is no matching meta property. 

Realized during this that the fragment and target code previously written executes after Semantic Linkbacks, so had to move everything earlier in the chain of events. 

The goal is to have webmentions move a bit away from the pingback mirrored implementation, but still keeping backward compatibility with that. That said, there is a proposal(https://core.trac.wordpress.org/ticket/17771) that discusses this issue for a different reason...