### PR TITLE
Attachments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,6 @@ matrix:
     env: WP_VERSION=4.7 WP_MULTISITE=0
   - php: 5.4
     env: WP_VERSION=4.7 WP_MULTISITE=0
-  - php: 5.3
-    env: WP_VERSION=4.7 WP_MULTISITE=0
-    dist: precise
-  - php: 5.2
-    env: WP_VERSION=4.7 WP_MULTISITE=0
-    dist: precise
 before_script:
 - |
   # Remove Xdebug for a huge performance increase:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,7 +66,7 @@ module.exports = function(grunt) {
         options: {
           mainFile: 'webmention.php',
           domainPath: '/languages',
-          exclude: ['bin/.*', '.git/.*', 'vendor/.*', 'node_modules/.*'],
+          exclude: ['bin/.*', '.git/.*', 'vendor/.*', 'node_modules/.*', 'tests/*'],
           potFilename: 'webmention.pot',
           type: 'wp-plugin',
           updateTimestamp: true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,7 +66,7 @@ module.exports = function(grunt) {
         options: {
           mainFile: 'webmention.php',
           domainPath: '/languages',
-          exclude: ['bin/.*', '.git/.*', 'vendor/.*'],
+          exclude: ['bin/.*', '.git/.*', 'vendor/.*', 'node_modules/.*'],
           potFilename: 'webmention.pot',
           type: 'wp-plugin',
           updateTimestamp: true

--- a/includes/class-webmention-admin.php
+++ b/includes/class-webmention-admin.php
@@ -330,12 +330,12 @@ class Webmention_Admin {
 		);
 		register_setting(
 			'webmention',
-			'webmention_support_pages',
+			'webmention_support_post_types',
 			array(
-				'type'         => 'boolean',
-				'description'  => esc_html__( 'Enable Webmention support for pages', 'webmention' ),
+				'type'         => 'string',
+				'description'  => esc_html__( 'Enable Webmention support for post types', 'webmention' ),
 				'show_in_rest' => true,
-				'default'      => 1,
+				'default'      => array( 'post', 'pages' ),
 			)
 		);
 		register_setting(

--- a/includes/class-webmention-admin.php
+++ b/includes/class-webmention-admin.php
@@ -330,6 +330,16 @@ class Webmention_Admin {
 		);
 		register_setting(
 			'webmention',
+			'webmention_send_media_mentions',
+			array(
+				'type'         => 'boolean',
+				'description'  => esc_html__( 'Disable sending webmentions for media links(image, video, and audio tags', 'webmention' ),
+				'show_in_rest' => true,
+				'default'      => 1,
+			)
+		);
+		register_setting(
+			'webmention',
 			'webmention_support_post_types',
 			array(
 				'type'         => 'string',

--- a/includes/class-webmention-admin.php
+++ b/includes/class-webmention-admin.php
@@ -333,7 +333,7 @@ class Webmention_Admin {
 			'webmention_disable_media_mentions',
 			array(
 				'type'         => 'boolean',
-				'description'  => esc_html__( 'Disable sending webmentions for media links(image, video, and audio tags', 'webmention' ),
+				'description'  => esc_html__( 'Disable sending webmentions for media links (image, video, and audio tags)', 'webmention' ),
 				'show_in_rest' => true,
 				'default'      => 1,
 			)

--- a/includes/class-webmention-admin.php
+++ b/includes/class-webmention-admin.php
@@ -330,7 +330,7 @@ class Webmention_Admin {
 		);
 		register_setting(
 			'webmention',
-			'webmention_send_media_mentions',
+			'webmention_disable_media_mentions',
 			array(
 				'type'         => 'boolean',
 				'description'  => esc_html__( 'Disable sending webmentions for media links(image, video, and audio tags', 'webmention' ),

--- a/includes/class-webmention-sender.php
+++ b/includes/class-webmention-sender.php
@@ -149,13 +149,13 @@ class Webmention_Sender {
 		// get post
 		$post = get_post( $post_id );
 
-		$media = (0 === get_option( 'webmention_send_media_mentions' ) );
+		$support_media_urls = ( 0 === get_option( 'webmention_send_media_mentions' ) );
 
 		// initialize links array
-		$links = html_extract_urls( $post->post_content, $media );
+		$urls = webmention_extract_urls( $post->post_content, $support_media_urls );
 
 		// filter links
-		$targets = apply_filters( 'webmention_links', $links, $post_id );
+		$targets = apply_filters( 'webmention_links', $urls, $post_id );
 		$targets = array_unique( $targets );
 		$pung    = get_pung( $post );
 		$ping    = array();

--- a/includes/class-webmention-sender.php
+++ b/includes/class-webmention-sender.php
@@ -149,8 +149,10 @@ class Webmention_Sender {
 		// get post
 		$post = get_post( $post_id );
 
+		$media = get_option( 'webmention_send_media_mentions' );
+
 		// initialize links array
-		$links = html_extract_urls( $post->post_content );
+		$links = html_extract_urls( $post->post_content, $media );
 
 		// filter links
 		$targets = apply_filters( 'webmention_links', $links, $post_id );

--- a/includes/class-webmention-sender.php
+++ b/includes/class-webmention-sender.php
@@ -150,7 +150,7 @@ class Webmention_Sender {
 		$post = get_post( $post_id );
 
 		// initialize links array
-		$links = wp_extract_urls( $post->post_content );
+		$links = html_extract_urls( $post->post_content );
 
 		// filter links
 		$targets = apply_filters( 'webmention_links', $links, $post_id );

--- a/includes/class-webmention-sender.php
+++ b/includes/class-webmention-sender.php
@@ -149,7 +149,7 @@ class Webmention_Sender {
 		// get post
 		$post = get_post( $post_id );
 
-		$media = get_option( 'webmention_send_media_mentions' );
+		$media = (0 === get_option( 'webmention_send_media_mentions' ) );
 
 		// initialize links array
 		$links = html_extract_urls( $post->post_content, $media );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -108,7 +108,7 @@ function webmention_url_to_postid( $url ) {
 		return apply_filters( 'webmention_post_id', get_option( 'webmention_home_mentions' ), $url );
 	}
 	$id = url_to_postid( $url );
-	if ( ! $id ) {
+	if ( ! $id && post_type_supports( 'attachment', 'webmentions' ) ) {
 		$ext = pathinfo( wp_parse_url( $url, PHP_URL_PATH ), PATHINFO_EXTENSION );
 		if ( ! empty( $ext ) ) {
 			$id = attachment_url_to_postid( $url );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -107,8 +107,14 @@ function webmention_url_to_postid( $url ) {
 	if ( '/' === wp_make_link_relative( trailingslashit( $url ) ) ) {
 		return apply_filters( 'webmention_post_id', get_option( 'webmention_home_mentions' ), $url );
 	}
-
-	return apply_filters( 'webmention_post_id', url_to_postid( $url ), $url );
+	$id = url_to_postid( $url );
+	if ( ! $id ) {
+		$ext = pathinfo( wp_parse_url( $url, PHP_URL_PATH ), PATHINFO_EXTENSION );
+		if ( ! empty( $ext ) ) {
+			$id = attachment_url_to_postid( $url );
+		}
+	}
+	return apply_filters( 'webmention_post_id', $id, $url );
 }
 
 function webmention_extract_domain( $url ) {
@@ -269,3 +275,57 @@ if ( ! function_exists( 'is_avatar_comment_type' ) ) :
 			return in_array( $comment_type, (array) $allowed_comment_types, true );
 	}
 endif;
+
+if ( ! function_exists( 'webmention_load_domdocument' ) ) :
+	function webmention_load_domdocument( $content ) {
+		if ( class_exists( 'Masterminds\\HTML5' ) ) {
+			$doc = new \Masterminds\HTML5( array( 'disable_html_ns' => true ) );
+			$doc = $doc->loadHTML( $content );
+		} else {
+			$doc = new DOMDocument();
+			libxml_use_internal_errors( true );
+			if ( function_exists( 'mb_convert_encoding' ) ) {
+				$content = mb_convert_encoding( $content, 'HTML-ENTITIES', mb_detect_encoding( $content ) );
+			}
+			$doc->loadHTML( $content );
+			libxml_use_internal_errors( false );
+		}
+		return $doc;
+	}
+endif;
+
+
+/**
+ * Use DOMDocument to extract URLs from HTML content
+ *
+ *
+ * @param string $content HTML Content to extract URLs from.
+ * @param boolean $media Extract media URLs not just traditional links
+ * @return array URLs found in passed string.
+ */
+function html_extract_urls( $content, $media = false ) {
+	$doc        = webmention_load_domdocument( $content );
+	$xpath      = new DOMXPath( $doc );
+	$attributes = array(
+		'cite' => array( 'blockquote', 'del', 'ins', 'q' ),
+		'href' => array( 'a', 'area' ),
+	);
+	$mediatags  = array(
+		'data'   => array( 'object' ),
+		'poster' => array( 'video' ),
+		'src'    => array( 'audio', 'embed', 'iframe', 'img', 'input', 'source', 'track', 'video' ),
+	);
+	if ( $media ) {
+		$attributes = array_merge( $attributes, $mediatags );
+	}
+	$links = array();
+	foreach ( $attributes as $attribute => $elements ) {
+		foreach ( $elements as $element ) {
+			foreach ( $xpath->query( sprintf( '//%1$s[@%2$s]', $element, $attribute ) ) as $url ) {
+				$links[] = $url->getAttribute( $attribute );
+			}
+		}
+	}
+
+	return array_filter( $links );
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -278,18 +278,14 @@ endif;
 
 if ( ! function_exists( 'webmention_load_domdocument' ) ) :
 	function webmention_load_domdocument( $content ) {
-		if ( class_exists( 'Masterminds\\HTML5' ) ) {
-			$doc = new \Masterminds\HTML5( array( 'disable_html_ns' => true ) );
-			$doc = $doc->loadHTML( $content );
-		} else {
-			$doc = new DOMDocument();
-			libxml_use_internal_errors( true );
-			if ( function_exists( 'mb_convert_encoding' ) ) {
-				$content = mb_convert_encoding( $content, 'HTML-ENTITIES', mb_detect_encoding( $content ) );
-			}
-			$doc->loadHTML( $content );
-			libxml_use_internal_errors( false );
+		$doc = new DOMDocument();
+		libxml_use_internal_errors( true );
+		if ( function_exists( 'mb_convert_encoding' ) ) {
+			$content = mb_convert_encoding( $content, 'HTML-ENTITIES', mb_detect_encoding( $content ) );
 		}
+		$doc->loadHTML( $content );
+		libxml_use_internal_errors( false );
+
 		return $doc;
 	}
 endif;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -294,34 +294,39 @@ endif;
 /**
  * Use DOMDocument to extract URLs from HTML content
  *
+ * @param string  $content            HTML Content to extract URLs from.
+ * @param boolean $support_media_urls Extract media URLs not just traditional links
  *
- * @param string $content HTML Content to extract URLs from.
- * @param boolean $media Extract media URLs not just traditional links
  * @return array URLs found in passed string.
  */
-function html_extract_urls( $content, $media = false ) {
-	$doc        = webmention_load_domdocument( $content );
-	$xpath      = new DOMXPath( $doc );
+function webmention_extract_urls( $content, $support_media_urls = false ) {
+	$doc   = webmention_load_domdocument( $content );
+	$xpath = new DOMXPath( $doc );
+
 	$attributes = array(
 		'cite' => array( 'blockquote', 'del', 'ins', 'q' ),
 		'href' => array( 'a', 'area' ),
 	);
-	$mediatags  = array(
+
+	$media_attributes = array(
 		'data'   => array( 'object' ),
 		'poster' => array( 'video' ),
 		'src'    => array( 'audio', 'embed', 'iframe', 'img', 'input', 'source', 'track', 'video' ),
 	);
-	if ( $media ) {
-		$attributes = array_merge( $attributes, $mediatags );
+
+	if ( $support_media_urls ) {
+		$attributes = array_merge( $attributes, $media_attributes );
 	}
-	$links = array();
+
+	$urls = array();
+
 	foreach ( $attributes as $attribute => $elements ) {
 		foreach ( $elements as $element ) {
 			foreach ( $xpath->query( sprintf( '//%1$s[@%2$s]', $element, $attribute ) ) as $url ) {
-				$links[] = $url->getAttribute( $attribute );
+				$urls[] = $url->getAttribute( $attribute );
 			}
 		}
 	}
 
-	return array_filter( $links );
+	return array_filter( $urls );
 }

--- a/languages/webmention.pot
+++ b/languages/webmention.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Webmention 3.8.11\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wordpress-webmention\n"
-"POT-Creation-Date: 2019-08-03 20:06:12+00:00\n"
+"POT-Creation-Date: 2019-09-08 13:49:27+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -182,31 +182,35 @@ msgstr ""
 msgid "Disable self Webmentions on the same domain"
 msgstr ""
 
-#: includes/class-webmention-admin.php:336 templates/webmention-settings.php:59
-msgid "Enable Webmention support for pages"
+#: includes/class-webmention-admin.php:336
+msgid "Disable sending webmentions for media links (image, video, and audio tags)"
 msgstr ""
 
 #: includes/class-webmention-admin.php:346
-msgid "Show Webmention comment-form"
+msgid "Enable Webmention support for post types"
 msgstr ""
 
 #: includes/class-webmention-admin.php:356
-msgid "Change the text of the Webmention comment-form"
+msgid "Show Webmention comment-form"
 msgstr ""
 
 #: includes/class-webmention-admin.php:366
-msgid "Where to direct Mentions of the home page"
+msgid "Change the text of the Webmention comment-form"
 msgstr ""
 
 #: includes/class-webmention-admin.php:376
-msgid "Automatically approve Webmentions from these domains"
+msgid "Where to direct Mentions of the home page"
 msgstr ""
 
 #: includes/class-webmention-admin.php:386
+msgid "Automatically approve Webmentions from these domains"
+msgstr ""
+
+#: includes/class-webmention-admin.php:396
 msgid "Show Avatars on Webmentions"
 msgstr ""
 
-#: includes/class-webmention-admin.php:398
+#: includes/class-webmention-admin.php:408
 msgid ""
 "Webmentions are an explicit feature of your content management system: by "
 "sending a webmention to the webmention endpoint of this website, you "
@@ -216,55 +220,55 @@ msgid ""
 "you are aware of it being published."
 msgstr ""
 
-#: includes/class-webmention-admin.php:399
+#: includes/class-webmention-admin.php:409
 msgid ""
 "You can at any time request the removal of one or all webmentions "
 "originating from your website."
 msgstr ""
 
-#: includes/class-webmention-admin.php:401
+#: includes/class-webmention-admin.php:411
 msgid "Processing"
 msgstr ""
 
-#: includes/class-webmention-admin.php:402
+#: includes/class-webmention-admin.php:412
 msgid ""
 "Incoming Webmentions are handled as a request to process personal data that "
 "you make available by explicitly providing metadata in your website's "
 "markup."
 msgstr ""
 
-#: includes/class-webmention-admin.php:404
+#: includes/class-webmention-admin.php:414
 msgid "Publishing"
 msgstr ""
 
-#: includes/class-webmention-admin.php:405
+#: includes/class-webmention-admin.php:415
 msgid ""
 "An incoming Webmention request is by design a request for publishing a "
 "comment from elsewhere on the web; this is what the protocol was designed "
 "for and why it is active on your website."
 msgstr ""
 
-#: includes/class-webmention-admin.php:407
+#: includes/class-webmention-admin.php:417
 msgid "Personal data"
 msgstr ""
 
-#: includes/class-webmention-admin.php:408
+#: includes/class-webmention-admin.php:418
 msgid "The Webmention plugin processes the following data (if available):"
 msgstr ""
 
-#: includes/class-webmention-admin.php:411
+#: includes/class-webmention-admin.php:421
 msgid "Your name"
 msgstr ""
 
-#: includes/class-webmention-admin.php:412
+#: includes/class-webmention-admin.php:422
 msgid "The profile picture from your website"
 msgstr ""
 
-#: includes/class-webmention-admin.php:413
+#: includes/class-webmention-admin.php:423
 msgid "The URL of your website"
 msgstr ""
 
-#: includes/class-webmention-admin.php:414
+#: includes/class-webmention-admin.php:424
 msgid "Personal information you include in your post"
 msgstr ""
 
@@ -376,7 +380,7 @@ msgid ""
 "contain a link to this post's permalink URL. Your response will then appear "
 "(possibly after moderation) on this page. Want to update or remove your "
 "response? Update or delete your post and re-enter your post's URL again. "
-"(<a href=\"https://indieweb.org/webmention\">Learn More</a>)"
+"(<a href=\"http://indieweb.org/webmention\">Learn More</a>)"
 msgstr ""
 
 #: templates/webmention-api-message.php:11
@@ -394,7 +398,7 @@ msgstr ""
 msgid "Ping me!"
 msgstr ""
 
-#: templates/webmention-comment.php:47
+#: templates/webmention-comment.php:48
 #. translators: 1: date, 2: time
 msgid "%1$s at %2$s"
 msgstr ""
@@ -421,17 +425,16 @@ msgid ""
 "your post.\""
 msgstr ""
 
-#: templates/webmention-endpoint-form.php:144
-msgid ""
-"Learn more about Webmentions at <a "
-"href=\"https://webmention.net\">webmention.net</a>"
+#: templates/webmention-endpoint-form.php:147
+#. Translators: placeholder will be an html link to webmention.net
+msgid "Learn more about Webmentions at %s"
 msgstr ""
-s
+
 #: templates/webmention-settings.php:7
 msgid "Sender"
 msgstr ""
 
-#: templates/webmention-settings.php:12
+#: templates/webmention-settings.php:11
 msgid ""
 "The Webmention plugin primarily handles sending/receiving notifications of "
 "mentions from other websites, so the format of the comments can look odd on "
@@ -442,78 +445,94 @@ msgid ""
 "for displaying many reply types as facepiles for improved user interface."
 msgstr ""
 
-#: templates/webmention-settings.php:18
+#: templates/webmention-settings.php:15
 msgid "A Webmention Sender is an implementation that sends Webmentions."
 msgstr ""
 
-#: templates/webmention-settings.php:22
+#: templates/webmention-settings.php:19
 msgid "Self-Ping settings"
 msgstr ""
 
-#: templates/webmention-settings.php:28
+#: templates/webmention-settings.php:24
 msgid "Disable self-pings on the same URL"
 msgstr ""
 
-#: templates/webmention-settings.php:37
+#: templates/webmention-settings.php:25
+msgid "(for example \"http://example.com/?p=123\")"
+msgstr ""
+
+#: templates/webmention-settings.php:32
 msgid "Disable self-pings on the same Domain"
 msgstr ""
 
-#: templates/webmention-settings.php:47
-msgid "Receiver"
+#: templates/webmention-settings.php:33
+msgid "(for example \"example.com\")"
+msgstr ""
+
+#: templates/webmention-settings.php:40
+msgid "Disable sending webmentions for media links(image, video, audio)"
 msgstr ""
 
 #: templates/webmention-settings.php:49
+msgid "Receiver"
+msgstr ""
+
+#: templates/webmention-settings.php:51
 msgid ""
 "A Webmention Receiver is an implementation that receives Webmentions to one "
 "or more target URLs on which the Receiver's Webmention endpoint is "
 "advertised."
 msgstr ""
 
-#: templates/webmention-settings.php:53
-msgid "Webmention support for pages"
+#: templates/webmention-settings.php:55
+msgid "Webmention support for post types"
 msgstr ""
 
-#: templates/webmention-settings.php:65
+#: templates/webmention-settings.php:58
+msgid "Enable Webmention support for the following post types:"
+msgstr ""
+
+#: templates/webmention-settings.php:74
 msgid "Set a page for mentions of the homepage to be sent to:"
 msgstr ""
 
-#: templates/webmention-settings.php:69
+#: templates/webmention-settings.php:79
 msgid "No homepage mentions"
 msgstr ""
 
-#: templates/webmention-settings.php:78
+#: templates/webmention-settings.php:89
 msgid "Visit site"
 msgstr ""
 
-#: templates/webmention-settings.php:86
+#: templates/webmention-settings.php:97
 msgid "Automatically approve Webmention from these domains"
 msgstr ""
 
-#: templates/webmention-settings.php:94
+#: templates/webmention-settings.php:105
 msgid ""
 "A Webmention received from a site that matches a domain in this list will "
-"be auto-approved. One domain (e.g. indieweb.org) per line.\n"
+"be auto-approved. One domain (e.g. indieweb.org) per line."
 msgstr ""
 
-#: templates/webmention-settings.php:102
+#: templates/webmention-settings.php:112
 msgid "Comment settings"
 msgstr ""
 
-#: templates/webmention-settings.php:109
+#: templates/webmention-settings.php:118
 msgid ""
 "Show a Webmention form at the comment section, to allow anyone to notify "
 "you of a mention."
 msgstr ""
 
-#: templates/webmention-settings.php:118
+#: templates/webmention-settings.php:127
 msgid "Change the default help text of the Webmention form"
 msgstr ""
 
-#: templates/webmention-settings.php:125
+#: templates/webmention-settings.php:134
 msgid "Avatars"
 msgstr ""
 
-#: templates/webmention-settings.php:131
+#: templates/webmention-settings.php:139
 msgid "Show avatars on webmentions if available."
 msgstr ""
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,10 +7,10 @@
 	<exclude-pattern>*/includes/*\.(inc|css|js|svg)</exclude-pattern>
 	<exclude-pattern>*/vendor/</exclude-pattern>
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="5.2-"/>
+	<config name="testVersion" value="5.4-"/>
 	<rule ref="WordPress-Core" />
 	<rule ref="PHPCompatibilityWP"/>
-	<config name="minimum_supported_wp_version" value="4.7"/>
+	<config name="minimum_supported_wp_version" value="4.9"/>
 	<rule ref="WordPress.WP.DeprecatedFunctions" />
 	<rule ref="WordPress.Files.FileName">
 		<properties>

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 **Tags:** webmention, pingback, trackback, linkback, indieweb, comment, response  
 **Requires at least:** 4.9  
 **Tested up to:** 5.2.2  
-**Stable tag:** 3.8.12  
+**Stable tag:** 4.0.0  
 **Requires PHP:** 5.4  
 **License:** MIT  
 **License URI:** https://opensource.org/licenses/MIT  
@@ -53,7 +53,7 @@ When declaring your custom post type, add post type support for webmentions by e
 
 ### How do I send/receive webmentions for attachments? ###
 
-You can enable receiving webmentions for attachments in webmention settings. You can enable sending webmentions for media links in the settings. 
+You can enable receiving webmentions for attachments in webmention settings. You can enable sending webmentions for media links in the settings.
 Please note that most receivers of webmentions do not support image, audio, and video files. In order to support receiving them on WordPress, webmention endpoint headers would have to be added at the webserver level.
 
 ### How can I handle Webmentions to my Homepage or Archive Pages? ###
@@ -84,7 +84,8 @@ As Webmention uses the REST API endpoint system, most up to date caching plugins
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
 
-### 3.8.12 ###
+### 4.0.0 ###
+
 * Add settings for enabling webmention support by public post type
 * Add setting for disabling sending media links...URLs attached to image, video, or audio tags
 * Switch from sending webmentions to all URLs in post content to only ones with proper HTML markup

--- a/readme.md
+++ b/readme.md
@@ -4,12 +4,12 @@
 **Contributors:** [pfefferle](https://profiles.wordpress.org/pfefferle), [dshanske](https://profiles.wordpress.org/dshanske)  
 **Donate link:** https://notiz.blog/donate/  
 **Tags:** webmention, pingback, trackback, linkback, indieweb, comment, response  
-**Requires at least:** 4.7  
+**Requires at least:** 4.9  
 **Tested up to:** 5.2.2  
-**Stable tag:** 3.8.11  
-**Requires PHP:** 5.2  
+**Stable tag:** 3.8.12  
+**Requires PHP:** 5.4  
 **License:** MIT  
-**License URI:** https://opensource.org/licenses/MIT
+**License URI:** https://opensource.org/licenses/MIT  
 
 Enable conversation across the web. When you link to a website you can send it a webmention to notify it and then that website
 may display your post as a comment, like, or other response, and presto, you’re having a conversation from one site to another!
@@ -37,8 +37,7 @@ Webmention is an update/replacement for Pingback or Trackback. Unlike the older 
 
 On the Settings --> Discussion Page in WordPress:
 
-* Activate sending Webmentions by checking the "Attempt to notify any blogs linked to from the article" option
-* Activate receiving Webmentions by checking the "Allow link notifications from other blogs (pingbacks and trackbacks) on new articles" option.
+* On the Webmention Settings page, decide which post types you want to enable webmentions to. By default, posts and pages.
 * Set a page to redirect homepage mentions to. This will automatically enable webmentions for that page.
 * WordPress disables notification to pages by default. Check the Enable Webmentions for Pages option to enable this.
 * If you want to enable a webmention form in the comment section, check the box.
@@ -50,7 +49,12 @@ You can use the `send_webmention($source, $target)` function and pass a source a
 
 ### How do I support Webmentions for my custom post type? ###
 
-When declaring your custom post type, add post type support for webmentions by either including it in your register_post_type entry or adding it later using add_post_type_support. This will also add support for receiving pingbacks and trackbacks as WordPress cannot currently distinguish between different linkback types.
+When declaring your custom post type, add post type support for webmentions by either including it in your register_post_type entry. This will also add support for receiving pingbacks and trackbacks as WordPress cannot currently distinguish between different linkback types. This can also be added in the webmention settings.
+
+### How do I send/receive webmentions for attachments? ###
+
+You can enable receiving webmentions for attachments in webmention settings. You can enable sending webmentions for media links in the settings. 
+Please note that most receivers of webmentions do not support image, audio, and video files. In order to support receiving them on WordPress, webmention endpoint headers would have to be added at the webserver level.
 
 ### How can I handle Webmentions to my Homepage or Archive Pages? ###
 
@@ -79,6 +83,11 @@ As Webmention uses the REST API endpoint system, most up to date caching plugins
 ## Changelog ##
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+### 3.8.12 ###
+* Add settings for enabling webmention support by public post type
+* Add setting for disabling sending media links...URLs attached to image, video, or audio tags
+* Switch from sending webmentions to all URLs in post content to only ones with proper HTML markup
 
 ### 3.8.11 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: pfefferle, dshanske
 Donate link: https://notiz.blog/donate/
 Tags: webmention, pingback, trackback, linkback, indieweb, comment, response
-Requires at least: 4.7
+Requires at least: 4.9
 Tested up to: 5.2.2
-Stable tag: 3.8.11
-Requires PHP: 5.2
+Stable tag: 3.8.12
+Requires PHP: 5.4
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -35,8 +35,7 @@ Webmention is an update/replacement for Pingback or Trackback. Unlike the older 
 
 On the Settings --> Discussion Page in WordPress:
 
-* Activate sending Webmentions by checking the "Attempt to notify any blogs linked to from the article" option
-* Activate receiving Webmentions by checking the "Allow link notifications from other blogs (pingbacks and trackbacks) on new articles" option.
+* On the Webmention Settings page, decide which post types you want to enable webmentions to. By default, posts and pages.
 * Set a page to redirect homepage mentions to. This will automatically enable webmentions for that page.
 * WordPress disables notification to pages by default. Check the Enable Webmentions for Pages option to enable this.
 * If you want to enable a webmention form in the comment section, check the box.
@@ -48,7 +47,12 @@ You can use the `send_webmention($source, $target)` function and pass a source a
 
 = How do I support Webmentions for my custom post type? =
 
-When declaring your custom post type, add post type support for webmentions by either including it in your register_post_type entry or adding it later using add_post_type_support. This will also add support for receiving pingbacks and trackbacks as WordPress cannot currently distinguish between different linkback types.
+When declaring your custom post type, add post type support for webmentions by either including it in your register_post_type entry. This will also add support for receiving pingbacks and trackbacks as WordPress cannot currently distinguish between different linkback types. This can also be added in the webmention settings.
+
+= How do I send/receive webmentions for attachments? = 
+
+You can enable receiving webmentions for attachments in webmention settings. You can enable sending webmentions for media links in the settings. 
+Please note that most receivers of webmentions do not support image, audio, and video files. In order to support receiving them on WordPress, webmention endpoint headers would have to be added at the webserver level.
 
 = How can I handle Webmentions to my Homepage or Archive Pages? =
 
@@ -77,6 +81,11 @@ As Webmention uses the REST API endpoint system, most up to date caching plugins
 == Changelog ==
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+= 3.8.12 =
+* Add settings for enabling webmention support by public post type
+* Add setting for disabling sending media links...URLs attached to image, video, or audio tags
+* Switch from sending webmentions to all URLs in post content to only ones with proper HTML markup
 
 = 3.8.11 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://notiz.blog/donate/
 Tags: webmention, pingback, trackback, linkback, indieweb, comment, response
 Requires at least: 4.9
 Tested up to: 5.2.2
-Stable tag: 3.8.12
+Stable tag: 4.0.0
 Requires PHP: 5.4
 License: MIT
 License URI: https://opensource.org/licenses/MIT
@@ -49,9 +49,9 @@ You can use the `send_webmention($source, $target)` function and pass a source a
 
 When declaring your custom post type, add post type support for webmentions by either including it in your register_post_type entry. This will also add support for receiving pingbacks and trackbacks as WordPress cannot currently distinguish between different linkback types. This can also be added in the webmention settings.
 
-= How do I send/receive webmentions for attachments? = 
+= How do I send/receive webmentions for attachments? =
 
-You can enable receiving webmentions for attachments in webmention settings. You can enable sending webmentions for media links in the settings. 
+You can enable receiving webmentions for attachments in webmention settings. You can enable sending webmentions for media links in the settings.
 Please note that most receivers of webmentions do not support image, audio, and video files. In order to support receiving them on WordPress, webmention endpoint headers would have to be added at the webserver level.
 
 = How can I handle Webmentions to my Homepage or Archive Pages? =
@@ -82,7 +82,8 @@ As Webmention uses the REST API endpoint system, most up to date caching plugins
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
 
-= 3.8.12 =
+= 4.0.0 =
+
 * Add settings for enabling webmention support by public post type
 * Add setting for disabling sending media links...URLs attached to image, video, or audio tags
 * Switch from sending webmentions to all URLs in post content to only ones with proper HTML markup

--- a/templates/webmention-comment.php
+++ b/templates/webmention-comment.php
@@ -2,7 +2,7 @@
 global $wp_query, $post;
 $comment_id = $wp_query->query['replytocom'];
 $comment = get_comment( $comment_id );
-$target = '';
+$target  = '';
 
 if ( $comment->comment_author_url ) {
 	$target = $comment->comment_author_url;
@@ -21,7 +21,7 @@ if ( $comment->comment_parent ) {
 <html <?php language_attributes(); ?>>
 	<head>
 		<meta charset="<?php bloginfo( 'charset' ); ?>" />
-		<?php wp_head();?>
+		<?php wp_head(); ?>
 
 		<script type="text/javascript">
 			<!--

--- a/templates/webmention-settings.php
+++ b/templates/webmention-settings.php
@@ -37,6 +37,14 @@
 							<?php esc_html_e( 'Disable self-pings on the same Domain', 'webmention' ) ?>
 							<p class="description"><?php esc_html_e( '(for example "example.com")', 'webmention' ); ?></p>
 						</label>
+
+						<br />
+
+						<label for="webmention_disable_media_mentions">
+							<input type="checkbox" name="webmention_disable_media_mentions" id="webmention_disable_media_mentions" value="1" <?php
+								echo checked( true, get_option( 'webmention_disable_media_mentions' ) );  ?> />
+							<?php esc_html_e( 'Disable sending webmentions for media links(image, video, audio)', 'webmention' ) ?>
+						</label>
 					</fieldset>
 				</td>
 			</tr>

--- a/templates/webmention-settings.php
+++ b/templates/webmention-settings.php
@@ -8,10 +8,7 @@
 
 		<?php if ( ! class_exists( 'Semantic_Linkbacks_Plugin' ) ) : ?>
 		<div class="notice notice-warning">
-			<p><?php printf (
-				__( 'The Webmention plugin primarily handles sending/receiving notifications of mentions from other websites, so the format of the comments can look odd on one\'s site. We highly recommend also installing and activating the <a class="thickbox open-plugin-details-modal" href="%1$s" target_"blank">Semantic Linkbacks Plugin</a> which has better parsing and display capabilities to allow richer looking comments as well as options for displaying many reply types as facepiles for improved user interface.', 'webmention' ),
-				admin_url( '/plugin-install.php?tab=plugin-information&plugin=semantic-linkbacks&TB_iframe=true' )
-			); ?></p>
+			<p><?php printf ( __( 'The Webmention plugin primarily handles sending/receiving notifications of mentions from other websites, so the format of the comments can look odd on one\'s site. We highly recommend also installing and activating the <a class="thickbox open-plugin-details-modal" href="%1$s" target_"blank">Semantic Linkbacks Plugin</a> which has better parsing and display capabilities to allow richer looking comments as well as options for displaying many reply types as facepiles for improved user interface.', 'webmention' ), admin_url( '/plugin-install.php?tab=plugin-information&plugin=semantic-linkbacks&TB_iframe=true' ) ); ?></p>
 		</div>
 		<?php endif; ?>
 
@@ -23,7 +20,7 @@
 				<td>
 					<fieldset>
 						<label for="webmention_disable_selfpings_same_url">
-							<input type="checkbox" name="webmention_disable_selfpings_same_url" id="webmention_disable_selfpings_same_url" value="1" <?php echo checked( true, get_option( 'webmention_disable_selfpings_same_url' ) );  ?> />
+							<input type="checkbox" name="webmention_disable_selfpings_same_url" id="webmention_disable_selfpings_same_url" value="1" <?php echo checked( true, get_option( 'webmention_disable_selfpings_same_url' ) ); ?> />
 							<?php esc_html_e( 'Disable self-pings on the same URL', 'webmention' ); ?>
 							<p class="description"><?php esc_html_e( '(for example "http://example.com/?p=123")', 'webmention' ); ?></p>
 						</label>
@@ -31,7 +28,7 @@
 						<br />
 
 						<label for="webmention_disable_selfpings_same_domain">
-							<input type="checkbox" name="webmention_disable_selfpings_same_domain" id="webmention_disable_selfpings_same_domain" value="1" <?php echo checked( true, get_option( 'webmention_disable_selfpings_same_domain' ) );  ?> />
+							<input type="checkbox" name="webmention_disable_selfpings_same_domain" id="webmention_disable_selfpings_same_domain" value="1" <?php echo checked( true, get_option( 'webmention_disable_selfpings_same_domain' ) ); ?> />
 							<?php esc_html_e( 'Disable self-pings on the same Domain', 'webmention' ); ?>
 							<p class="description"><?php esc_html_e( '(for example "example.com")', 'webmention' ); ?></p>
 						</label>
@@ -105,8 +102,7 @@
 						</p>
 						<p class="description">
 							<label for="webmention_approve_domains">
-								<?php esc_html_e( 'A Webmention received from a site that matches a domain in this list will be auto-approved. One domain (e.g. indieweb.org) per line.
-', 'webmention' ); ?>
+								<?php esc_html_e( 'A Webmention received from a site that matches a domain in this list will be auto-approved. One domain (e.g. indieweb.org) per line.', 'webmention' ); ?>
 							</label>
 						</p>
 					</fieldset>
@@ -118,9 +114,8 @@
 					<fieldset>
 						<p>
 							<label for="webmention_show_comment_form">
-								<input type="checkbox" name="webmention_show_comment_form" id="webmention_show_comment_form" value="1" <?php
-									echo checked( true, get_option( 'webmention_show_comment_form' ) );  ?> />
-								<?php esc_html_e( 'Show a Webmention form at the comment section, to allow anyone to notify you of a mention.', 'webmention' ) ?>
+								<input type="checkbox" name="webmention_show_comment_form" id="webmention_show_comment_form" value="1" <?php echo checked( true, get_option( 'webmention_show_comment_form' ) ); ?> />
+								<?php esc_html_e( 'Show a Webmention form at the comment section, to allow anyone to notify you of a mention.', 'webmention' ); ?>
 							</label>
 						</p>
 
@@ -140,9 +135,8 @@
 				<td>
 					<fieldset>
 						<label for="webmention_avatars">
-							<input type="checkbox" name="webmention_avatars" id="webmention_avatars" value="1" <?php
-								echo checked( true, get_option( 'webmention_avatars', 1 ) );  ?> />
-							<?php esc_html_e( 'Show avatars on webmentions if available.', 'webmention' ) ?>
+							<input type="checkbox" name="webmention_avatars" id="webmention_avatars" value="1" <?php echo checked( true, get_option( 'webmention_avatars', 1 ) ); ?> />
+							<?php esc_html_e( 'Show avatars on webmentions if available.', 'webmention' ); ?>
 						</label>
 					</fieldset>
 				</td>

--- a/templates/webmention-settings.php
+++ b/templates/webmention-settings.php
@@ -23,27 +23,24 @@
 				<td>
 					<fieldset>
 						<label for="webmention_disable_selfpings_same_url">
-							<input type="checkbox" name="webmention_disable_selfpings_same_url" id="webmention_disable_selfpings_same_url" value="1" <?php
-								echo checked( true, get_option( 'webmention_disable_selfpings_same_url' ) );  ?> />
-							<?php esc_html_e( 'Disable self-pings on the same URL', 'webmention' ) ?>
+							<input type="checkbox" name="webmention_disable_selfpings_same_url" id="webmention_disable_selfpings_same_url" value="1" <?php echo checked( true, get_option( 'webmention_disable_selfpings_same_url' ) );  ?> />
+							<?php esc_html_e( 'Disable self-pings on the same URL', 'webmention' ); ?>
 							<p class="description"><?php esc_html_e( '(for example "http://example.com/?p=123")', 'webmention' ); ?></p>
 						</label>
 
 						<br />
 
 						<label for="webmention_disable_selfpings_same_domain">
-							<input type="checkbox" name="webmention_disable_selfpings_same_domain" id="webmention_disable_selfpings_same_domain" value="1" <?php
-								echo checked( true, get_option( 'webmention_disable_selfpings_same_domain' ) );  ?> />
-							<?php esc_html_e( 'Disable self-pings on the same Domain', 'webmention' ) ?>
+							<input type="checkbox" name="webmention_disable_selfpings_same_domain" id="webmention_disable_selfpings_same_domain" value="1" <?php echo checked( true, get_option( 'webmention_disable_selfpings_same_domain' ) );  ?> />
+							<?php esc_html_e( 'Disable self-pings on the same Domain', 'webmention' ); ?>
 							<p class="description"><?php esc_html_e( '(for example "example.com")', 'webmention' ); ?></p>
 						</label>
 
 						<br />
 
 						<label for="webmention_disable_media_mentions">
-							<input type="checkbox" name="webmention_disable_media_mentions" id="webmention_disable_media_mentions" value="1" <?php
-								echo checked( true, get_option( 'webmention_disable_media_mentions' ) );  ?> />
-							<?php esc_html_e( 'Disable sending webmentions for media links(image, video, audio)', 'webmention' ) ?>
+							<input type="checkbox" name="webmention_disable_media_mentions" id="webmention_disable_media_mentions" value="1" <?php echo checked( true, get_option( 'webmention_disable_media_mentions' ) ); ?> />
+							<?php esc_html_e( 'Disable sending webmentions for media links(image, video, audio)', 'webmention' ); ?>
 						</label>
 					</fieldset>
 				</td>
@@ -61,14 +58,18 @@
 				<th scope="row"><?php esc_html_e( 'Webmention support for post types', 'webmention' ); ?></th>
 				<td>
 					<fieldset>
-						<label for="webmention_support_post_types">
-							<?php
-								webmention_public_post_types( get_option( 'webmention_support_post_types' ) );
-							?>
-							<br />
+						<?php esc_html_e( 'Enable Webmention support for the following post types:', 'webmention' ); ?>
 
-							<?php esc_html_e( 'Enable Webmention support for post types', 'webmention' ); ?>
-						</label>
+						<?php $post_types = get_post_types( array( 'public' => true ), 'objects' ); ?>
+						<?php $support_post_types = get_option( 'webmention_support_post_types', array( 'post', 'page' ) ) ? get_option( 'webmention_support_post_types', array( 'post', 'page' ) ) : array(); ?>
+						<ul>
+						<?php foreach ( $post_types as $post_type ) { ?>
+							<li>
+								<input type="checkbox" id="webmention_support_post_types" name="webmention_support_post_types[]" value="<?php echo esc_attr( $post_type->name ); ?>" <?php echo checked( true, in_array( $post_type->name, $support_post_types, true ) ); ?> />
+								<label for="<?php echo esc_attr( $post_type->name ); ?>"><?php echo esc_html( $post_type->label ); ?></label>
+							</li>
+						<?php } ?>
+						</ul>
 
 						<br />
 
@@ -76,12 +77,14 @@
 							<?php esc_html_e( 'Set a page for mentions of the homepage to be sent to:', 'webmention' ); ?>
 
 							<?php
-							wp_dropdown_pages( array(
-								'show_option_none' => esc_html__( 'No homepage mentions', 'webmention' ),
-								'name'             => 'webmention_home_mentions',
-								'id'               => 'webmention_home_mentions',
-								'selected'         => get_option( 'webmention_home_mentions' ),
-							) );
+							wp_dropdown_pages(
+								array(
+									'show_option_none' => esc_html__( 'No homepage mentions', 'webmention' ),
+									'name'             => 'webmention_home_mentions',
+									'id'               => 'webmention_home_mentions',
+									'selected'         => get_option( 'webmention_home_mentions' ),
+								)
+							);
 							?>
 
 							<?php

--- a/templates/webmention-settings.php
+++ b/templates/webmention-settings.php
@@ -50,13 +50,16 @@
 
 		<table class="form-table">
 			<tr>
-				<th scope="row"><?php esc_html_e( 'Webmention support for pages', 'webmention' ); ?></th>
+				<th scope="row"><?php esc_html_e( 'Webmention support for post types', 'webmention' ); ?></th>
 				<td>
 					<fieldset>
-						<label for="webmention_support_pages">
-							<input type="checkbox" name="webmention_support_pages" id="webmention_support_pages" value="1" <?php
-								echo checked( true, get_option( 'webmention_support_pages' ) );  ?> />
-							<?php esc_html_e( 'Enable Webmention support for pages', 'webmention' ); ?>
+						<label for="webmention_support_post_types">
+							<?php
+								webmention_public_post_types( get_option( 'webmention_support_post_types' ) );
+							?>
+							<br />
+
+							<?php esc_html_e( 'Enable Webmention support for post types', 'webmention' ); ?>
 						</label>
 
 						<br />

--- a/webmention.php
+++ b/webmention.php
@@ -92,25 +92,6 @@ function webmention_get_default_comment_status( $status, $post_type, $comment_ty
 	return $status;
 }
 
-function webmention_public_post_types( $checked ) {
-	if ( ! is_array( $checked ) ) {
-		$checked = array();
-	}
-	$post_types = get_post_types(
-		array(
-			'public' => true,
-		)
-	);
-
-	foreach ( $post_types as $type ) {
-		$post_type = get_post_type_object( $type );
-		echo '<ul>';
-		printf( '<li><input type="checkbox" id="webmention_support_post_types" name="webmention_support_post_types[]" value="%1$s" %2$s>', $type, in_array( $type, $checked, true ) ? 'checked' : '' );
-		printf( '<label for="%1$s">%2$s</label></li>', $type, $post_type->label );
-		echo '</ul>';
-	}
-}
-
 /**
  * render the comment form
  */

--- a/webmention.php
+++ b/webmention.php
@@ -31,10 +31,9 @@ add_action( 'admin_menu', array( 'Webmention_Admin', 'admin_menu' ) );
  * Initialize Webmention Plugin
  */
 function webmention_init() {
-	// Add a new feature type to posts for webmentions
-	add_post_type_support( 'post', 'webmentions' );
-	if ( 1 === (int) get_option( 'webmention_support_pages' ) ) {
-		add_post_type_support( 'page', 'webmentions' );
+	// Add support for webmentions to custom post types
+	foreach ( get_option( 'webmention_support_post_types', array( 'post', 'page' ) ) as $post_type ) {
+		add_post_type_support( $post_type, 'webmentions' );
 	}
 	if ( WP_DEBUG ) {
 		require_once dirname( __FILE__ ) . '/includes/debug.php';
@@ -89,6 +88,25 @@ function webmention_get_default_comment_status( $status, $post_type, $comment_ty
 	}
 
 	return $status;
+}
+
+function webmention_public_post_types( $checked ) {
+	if ( ! is_array( $checked ) ) {
+		$checked = array();
+	}
+	$post_types = get_post_types(
+		array(
+			'public' => true,
+		)
+	);
+
+	foreach ( $post_types as $type ) {
+		$post_type = get_post_type_object( $type );
+		echo '<ul>';
+		printf( '<li><input type="checkbox" id="webmention_support_post_types" name="webmention_support_post_types[]" value="%1$s" %2$s>', $type, in_array( $type, $checked, true ) ? 'checked' : '' );
+		printf( '<label for="%1$s">%2$s</label></li>', $type, $post_type->label );
+		echo '</ul>';
+	}
 }
 
 /**

--- a/webmention.php
+++ b/webmention.php
@@ -32,7 +32,9 @@ add_action( 'admin_menu', array( 'Webmention_Admin', 'admin_menu' ) );
  */
 function webmention_init() {
 	// Add support for webmentions to custom post types
-	foreach ( get_option( 'webmention_support_post_types', array( 'post', 'page' ) ) as $post_type ) {
+	$post_types = get_option( 'webmention_support_post_types', array( 'post', 'page' ) ) ? get_option( 'webmention_support_post_types', array( 'post', 'page' ) ) : array();
+
+	foreach ( $post_types as $post_type ) {
 		add_post_type_support( $post_type, 'webmentions' );
 	}
 	if ( WP_DEBUG ) {


### PR DESCRIPTION
This started as simply adding attachment support, but in order to support that, I upgraded the setting to allow one to add webmention support to any public post type.

webmention_to_post_id now tries to match attachment files to the attachment post id. 

In exploring this, and realizing that I couldn't support receiving webmentions to media files without adding the header on the server level(Thanks @pfefferle for leading me to that conclusion when it eluded me), I looked at the fact that we were sending out webmentions for every link in a post, and links in img, video, or audio tags would almost never be relevant, and there were other HTML elements that it made no sense to send webmentions for.

So now, it actually extracts valid links, not just URLs in content.