### PR TITLE
Hide headers if webmentions are not supported to that URL

### DIFF
--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -829,28 +829,36 @@ class Webmention_Receiver {
 	 *
 	 * @return boolean
 	 */
-	public static function receive_mentions() {
-		if ( 0 !== WEBMENTION_ALWAYS_SHOW_HEADERS ) {
+	public static function should_show_headers() {
+		if ( WEBMENTION_ALWAYS_SHOW_HEADERS ) {
 			return true;
 		}
+
+		return self::should_receive_mentions();
+	}
+
+	/**
+	 *
+	 *
+	 * @return boolean
+	 */
+	public static function should_receive_mentions() {
 		if ( ! is_singular() ) {
-			// Cache this as will be called twice in a page load
-			$post_id = wp_cache_get( base64_encode( get_self_link() ), 'wmurl' );
-			if ( false === $post_id ) {
-				$post_id = webmention_url_to_postid( get_self_link() );
-				wp_cache_set( base64_encode( get_self_link() ), $post_id, 'wmurl', 300 );
-			}
+			$post_id = webmention_url_to_postid( get_self_link() );
+
 			if ( ! $post_id ) {
 				return false;
 			}
 		}
 		// If the post type does not support webmentions do not even check if pings_open is set
 		if ( ! post_type_supports( get_post_type( $post_id ), 'webmentions' ) ) {
-				return false;
+			return false;
 		}
+
 		if ( pings_open( $post_id ) ) {
 			return true;
 		}
+
 		return false;
 	}
 
@@ -858,9 +866,10 @@ class Webmention_Receiver {
 	 * The Webmention autodicovery meta-tags
 	 */
 	public static function html_header() {
-		if ( ! self::receive_mentions() ) {
+		if ( ! self::should_show_headers() ) {
 			return;
 		}
+
 		printf( '<link rel="webmention" href="%s" />' . PHP_EOL, get_webmention_endpoint() );
 		// backwards compatibility with v0.1
 		printf( '<link rel="http://webmention.org/" href="%s" />' . PHP_EOL, get_webmention_endpoint() );
@@ -870,7 +879,7 @@ class Webmention_Receiver {
 	 * The Webmention autodicovery http-header
 	 */
 	public static function http_header() {
-		if ( ! self::receive_mentions() ) {
+		if ( ! self::should_show_headers() ) {
 			return;
 		}
 

--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -831,7 +831,11 @@ class Webmention_Receiver {
 	 */
 	public static function receive_mentions() {
 		// Cannot use is_singular as query is set up after send_headers and webmention_url_to_postid can be filtered to map other URLs to arbitrary posts
-		$post_id = webmention_url_to_postid( get_self_link() );
+		$post_id = wp_cache_get( base64_encode( get_self_link() ), 'wmurl' );
+		if ( false === $post_id ) {
+			$post_id = webmention_url_to_postid( get_self_link() );
+			wp_cache_set( base64_encode( get_self_link() ), $post_id, 'wmurl', 300 );
+		}
 		if ( ! $post_id ) {
 			return false;
 		}

--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -843,13 +843,16 @@ class Webmention_Receiver {
 	 * @return boolean
 	 */
 	public static function should_receive_mentions() {
-		if ( ! is_singular() ) {
+		if ( is_singular() ) {
+			$post_id = get_queried_object_id();
+		} else {
 			$post_id = webmention_url_to_postid( get_self_link() );
-
-			if ( ! $post_id ) {
-				return false;
-			}
 		}
+
+		if ( ! $post_id ) {
+			return false;
+		}
+
 		// If the post type does not support webmentions do not even check if pings_open is set
 		if ( ! post_type_supports( get_post_type( $post_id ), 'webmentions' ) ) {
 			return false;

--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -844,7 +844,7 @@ class Webmention_Receiver {
 	 */
 	public static function should_receive_mentions() {
 		if ( is_singular() ) {
-			$post_id = get_queried_object_id();
+			return pings_open();
 		} else {
 			$post_id = webmention_url_to_postid( get_self_link() );
 		}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -269,3 +269,20 @@ if ( ! function_exists( 'is_avatar_comment_type' ) ) :
 			return in_array( $comment_type, (array) $allowed_comment_types, true );
 	}
 endif;
+
+
+
+/* Backward compatibility for function available in version 5.3 and above */
+if ( ! function_exists( 'get_self_link' ) ) :
+	/**
+	 * Returns the link for the currently displayed feed.
+	 *
+	 * @since 5.3.0
+	 *
+	 * @return string Correct link for the atom:self element.
+	 */
+	function get_self_link() {
+		$host = @parse_url( home_url() );
+		return set_url_scheme( 'http://' . $host['host'] . wp_unslash( $_SERVER['REQUEST_URI'] ) );
+	}
+endif;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -104,16 +104,28 @@ function get_webmention_process_type() {
  * @uses apply_filters calls "webmention_post_id" on the post_ID
  */
 function webmention_url_to_postid( $url ) {
+	$id = wp_cache_get( base64_encode( $url ), 'webmention_url_to_postid' );
+
+	if ( false === $id ) {
+		return apply_filters( 'webmention_post_id', $id, $url );
+	}
+
 	if ( '/' === wp_make_link_relative( trailingslashit( $url ) ) ) {
 		return apply_filters( 'webmention_post_id', get_option( 'webmention_home_mentions' ), $url );
 	}
+
 	$id = url_to_postid( $url );
+
 	if ( ! $id && post_type_supports( 'attachment', 'webmentions' ) ) {
 		$ext = pathinfo( wp_parse_url( $url, PHP_URL_PATH ), PATHINFO_EXTENSION );
+
 		if ( ! empty( $ext ) ) {
 			$id = attachment_url_to_postid( $url );
 		}
 	}
+
+	wp_cache_set( base64_encode( $url ), $id, 'webmention_url_to_postid', 300 );
+
 	return apply_filters( 'webmention_post_id', $id, $url );
 }
 

--- a/webmention.php
+++ b/webmention.php
@@ -12,6 +12,8 @@
  * Domain Path: /languages
  */
 
+
+defined( 'WEBMENTION_ALWAYS_SHOW_HEADERS' ) || define( 'WEBMENTION_ALWAYS_SHOW_HEADERS', 0 );
 defined( 'WEBMENTION_COMMENT_APPROVE' ) || define( 'WEBMENTION_COMMENT_APPROVE', 0 );
 defined( 'WEBMENTION_COMMENT_TYPE' ) || define( 'WEBMENTION_COMMENT_TYPE', 'webmention' );
 


### PR DESCRIPTION
Address #75 and #152 

The problem with hiding headers prior was partially that is_singular() or anything requiring a global query variable isn't loaded when headers are sent, so it would always evaluate to false.

This uses get_self_link(scheduled for WordPress 5.3, see https://core.trac.wordpress.org/ticket/44838) to retrieve the URL currently being requested, then determines the post_id if applicable using webmention_to_postid, which means the existing filter could take archive or other pages and redirect them. It also works for the currently built in home page mention redirect.


