### PR TITLE
Improve Storage of Parameters

### DIFF
--- a/includes/class-webmention-admin.php
+++ b/includes/class-webmention-admin.php
@@ -49,23 +49,8 @@ class Webmention_Admin {
 		if ( ! $object instanceof WP_Comment ) {
 			return;
 		}
-		?>
-<label><?php esc_html_e( 'Webmention Target', 'webmention' ); ?></label>
-<input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $object->comment_ID, 'webmention_target_url', true ); ?>" />
-<br />
 
-<label><?php esc_html_e( 'Webmention Target Fragment', 'webmention' ); ?></label>
-<input type="text" class="widefat" disabled value="<?php echo get_comment_meta( $object->comment_ID, 'webmention_target_fragment', true ); ?>" />
-<br />
-
-<label><?php esc_html_e( 'Webmention Source', 'webmention' ); ?></label>
-<input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $object->comment_ID, 'webmention_source_url', true ); ?>" />
-<br />
-
-<label><?php esc_html_e( 'Webmention Creation Time', 'webmention' ); ?></label>
-<input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $object->comment_ID, 'webmention_created_at', true ); ?>" />
-<br />
-		<?php
+		load_template( dirname( __FILE__ ) . '/../templates/webmention-edit-comment-form.php' );
 	}
 
 	/**

--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -56,6 +56,15 @@ class Webmention_Receiver {
 	 * This is more to lay out the data structure than anything else.
 	 */
 	public static function register_meta() {
+
+		$args = array(
+			'type'         => 'string',
+			'description'  => esc_html__( 'Protocol for the Comment', 'webmention' ),
+			'single'       => true,
+			'show_in_rest' => true,
+		);
+		register_meta( 'comment', 'protocol', $args );
+
 		$args = array(
 			'type'         => 'string',
 			'description'  => esc_html__( 'Target URL for the Webmention', 'webmention' ),

--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -93,20 +93,20 @@ class Webmention_Receiver {
 		// Purpose of this is to store the original time as there is no modified time in the comment table.
 		$args = array(
 			'type'         => 'string',
-			'description'  => esc_html__( 'Original Creation Time for the Webmention (GMT)', 'webmention' ),
+			'description'  => esc_html__( 'Original Creation Time (GMT)', 'webmention' ),
 			'single'       => true,
 			'show_in_rest' => true,
 		);
-		register_meta( 'comment', 'webmention_created_at', $args );
+		register_meta( 'comment', 'created', $args );
 
 		// Purpose of this is to store the response code returned during verification
 		$args = array(
 			'type'         => 'string',
-			'description'  => esc_html__( 'Response Code Returned During Webmention Verification', 'webmention' ),
+			'description'  => esc_html__( 'Response Code Returned During Verification', 'webmention' ),
 			'single'       => true,
 			'show_in_rest' => true,
 		);
-		register_meta( 'comment', 'webmention_response_code', $args );
+		register_meta( 'comment', 'response_code', $args );
 
 		// Purpose of this is to store a vouch URL
 		$args = array(
@@ -236,12 +236,13 @@ class Webmention_Receiver {
 		$comment_meta = array();
 
 		$map = array(
-			'vouch'    => 'webmention_vouch_url',
-			'source'   => 'webmention_source_url',
-			'target'   => 'webmention_target_url',
-			'fragment' => 'webmention_target_fragment',
-			'created'  => 'webmention_created_at',
-			'protocol' => 'protocol',
+			'vouch'         => 'webmention_vouch_url',
+			'source'        => 'webmention_source_url',
+			'target'        => 'webmention_target_url',
+			'fragment'      => 'webmention_target_fragment',
+			'created'       => 'created',
+			'response_code' => 'response_code',
+			'protocol'      => 'protocol',
 		);
 
 		foreach ( $map as $key => $value ) {
@@ -498,7 +499,7 @@ class Webmention_Receiver {
 		}
 
 		// A valid response code from the other server would not be considered an error.
-		$response_code = wp_remote_retrieve_response_code( $response );
+		$data['response_code'] = $response_code = wp_remote_retrieve_response_code( $response );
 		// not an (x)html, sgml, or xml page, no use going further
 		if ( preg_match( '#(image|audio|video|model)/#is', wp_remote_retrieve_header( $response, 'content-type' ) ) ) {
 			return new WP_Error(

--- a/templates/webmention-edit-comment-form.php
+++ b/templates/webmention-edit-comment-form.php
@@ -11,6 +11,6 @@
 <input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $comment->comment_ID, 'webmention_source_url', true ); ?>" />
 <br />
 
-<label><?php esc_html_e( 'Webmention Creation Time', 'webmention' ); ?></label>
-<input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $comment->comment_ID, 'webmention_created_at', true ); ?>" />
+<label><?php esc_html_e( 'Creation Time', 'webmention' ); ?></label>
+<input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $comment->comment_ID, 'created', true ); ?>" />
 <br />

--- a/templates/webmention-edit-comment-form.php
+++ b/templates/webmention-edit-comment-form.php
@@ -3,10 +3,6 @@
 <input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $comment->comment_ID, 'webmention_target_url', true ); ?>" />
 <br />
 
-<label><?php esc_html_e( 'Webmention Target Fragment', 'webmention' ); ?></label>
-<input type="text" class="widefat" disabled value="<?php echo get_comment_meta( $comment->comment_ID, 'webmention_target_fragment', true ); ?>" />
-<br />
-
 <label><?php esc_html_e( 'Webmention Source', 'webmention' ); ?></label>
 <input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $comment->comment_ID, 'webmention_source_url', true ); ?>" />
 <br />


### PR DESCRIPTION
The primary  for this PR was to address the compact issue, where newer versions of PHP throw a warning if the variable you are running compact with isn't declared.

It introduces a new function, hooked onto the webmention_comment_data filter, that takes parameters passed in commentdata and stores them in the comment_meta array for saving into the database. It means it could be removed or replaced, or alternatively, the mapping list could be filtered in future.

As part of improving comment meta, I added storage of the response code, which had a registered meta key but wasn't being stored, moved the created key, which has yet to be used, which stored original webmention creation as opposed to what was later parsed, and started proactively adding the protocol key for webmention, which matches the activitypub plugin. 

I updated the meta box in the edit comment screen and noticed that we had two versions of it, so removed one.