### PR TITLE
Verify Using Media Type Rules

### DIFF
--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -230,13 +230,13 @@ class Webmention_Receiver {
 			return new WP_Error( 'source_missing', esc_html__( 'Source is missing', 'webmention' ), array( 'status' => 400 ) );
 		}
 
-		$source = urldecode( $params['source'] );
+		$source = self::normalize_url( urldecode( $params['source'] ) );
 
 		if ( ! isset( $params['target'] ) ) {
 			return new WP_Error( 'target_missing', esc_html__( 'Target is missing', 'webmention' ), array( 'status' => 400 ) );
 		}
 
-		$target = urldecode( $params['target'] );
+		$target = self::normalize_url( urldecode( $params['target'] ) );
 
 		if ( ! stristr( $target, preg_replace( '/^https?:\/\//i', '', home_url() ) ) ) {
 			return new WP_Error( 'target_mismatching_domain', esc_html__( 'Target is not on this domain', 'webmention' ), array( 'status' => 400 ) );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -106,7 +106,7 @@ function get_webmention_process_type() {
 function webmention_url_to_postid( $url ) {
 	$id = wp_cache_get( base64_encode( $url ), 'webmention_url_to_postid' );
 
-	if ( false === $id ) {
+	if ( false !== $id ) {
 		return apply_filters( 'webmention_post_id', $id, $url );
 	}
 


### PR DESCRIPTION
https://www.w3.org/TR/webmention/#webmention-verification

`The receiver SHOULD use per-media-type rules to determine whether the source document mentions the target URL. For example, in an [ HTML5] document, the receiver should look for <a href="*">, <img href="*">, <video src="*"> and other similar links.`

This also passes the DOMDocument object into the commentdata array so that PHP-MF2 can use it in a future iteration.

It includes @aaronpk's build_url and a normalizing function for URLs to help in comparisons.

Also, discovered another issue causing a failure, an inverted conditional in webmention_to_urlid.