### PR TITLE
Template

### DIFF
--- a/includes/class-webmention-admin.php
+++ b/includes/class-webmention-admin.php
@@ -49,23 +49,7 @@ class Webmention_Admin {
 		if ( ! $object instanceof WP_Comment ) {
 			return;
 		}
-		?>
-<label><?php esc_html_e( 'Webmention Target', 'webmention' ); ?></label>
-<input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $object->comment_ID, 'webmention_target_url', true ); ?>" />
-<br />
-
-<label><?php esc_html_e( 'Webmention Target Fragment', 'webmention' ); ?></label>
-<input type="text" class="widefat" disabled value="<?php echo get_comment_meta( $object->comment_ID, 'webmention_target_fragment', true ); ?>" />
-<br />
-
-<label><?php esc_html_e( 'Webmention Source', 'webmention' ); ?></label>
-<input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $object->comment_ID, 'webmention_source_url', true ); ?>" />
-<br />
-
-<label><?php esc_html_e( 'Webmention Creation Time', 'webmention' ); ?></label>
-<input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $object->comment_ID, 'webmention_created_at', true ); ?>" />
-<br />
-		<?php
+		load_template( dirname( __FILE__ ) . '/../templates/webmention-edit-comment-form.php' );
 	}
 
 	/**

--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -55,6 +55,14 @@ class Webmention_Receiver {
 	public static function register_meta() {
 		$args = array(
 			'type'         => 'string',
+			'description'  => esc_html__( 'Protocol Used to Receive', 'webmention' ),
+			'single'       => true,
+			'show_in_rest' => true,
+		);
+		register_meta( 'comment', 'protocol', $args );
+
+		$args = array(
+			'type'         => 'string',
 			'description'  => esc_html__( 'Target URL for the Webmention', 'webmention' ),
 			'single'       => true,
 			'show_in_rest' => true,
@@ -270,6 +278,7 @@ class Webmention_Receiver {
 		$comment_date                          = current_time( 'mysql' );
 		$comment_date_gmt                      = current_time( 'mysql', 1 );
 		$comment_meta['webmention_created_at'] = $comment_date_gmt;
+		$protocol                              = 'webmention';
 
 		if ( isset( $params['vouch'] ) ) {
 			// If there is a vouch pass it along
@@ -284,7 +293,7 @@ class Webmention_Receiver {
 		// change this if you want to auto approve your Webmentions
 		$comment_approved = WEBMENTION_COMMENT_APPROVE;
 
-		$commentdata = compact( 'comment_type', 'comment_approved', 'comment_agent', 'comment_date', 'comment_date_gmt', 'comment_meta', 'source', 'target', 'vouch' );
+		$commentdata = compact( 'protocol', 'comment_type', 'comment_approved', 'comment_agent', 'comment_date', 'comment_date_gmt', 'comment_meta', 'source', 'target', 'vouch' );
 
 		$commentdata['comment_post_ID']   = $comment_post_id;
 		$commentdata['comment_author_IP'] = $comment_author_ip;

--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -278,7 +278,7 @@ class Webmention_Receiver {
 		$comment_date                          = current_time( 'mysql' );
 		$comment_date_gmt                      = current_time( 'mysql', 1 );
 		$comment_meta['webmention_created_at'] = $comment_date_gmt;
-		$protocol                              = 'webmention';
+		$comment_meta['protocol']              = 'webmention';
 
 		if ( isset( $params['vouch'] ) ) {
 			// If there is a vouch pass it along
@@ -293,7 +293,7 @@ class Webmention_Receiver {
 		// change this if you want to auto approve your Webmentions
 		$comment_approved = WEBMENTION_COMMENT_APPROVE;
 
-		$commentdata = compact( 'protocol', 'comment_type', 'comment_approved', 'comment_agent', 'comment_date', 'comment_date_gmt', 'comment_meta', 'source', 'target', 'vouch' );
+		$commentdata = compact( 'comment_type', 'comment_approved', 'comment_agent', 'comment_date', 'comment_date_gmt', 'comment_meta', 'source', 'target', 'vouch' );
 
 		$commentdata['comment_post_ID']   = $comment_post_id;
 		$commentdata['comment_author_IP'] = $comment_author_ip;

--- a/templates/webmention-edit-comment-form.php
+++ b/templates/webmention-edit-comment-form.php
@@ -3,10 +3,6 @@
 <input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $comment->comment_ID, 'webmention_target_url', true ); ?>" />
 <br />
 
-<label><?php esc_html_e( 'Webmention Target Fragment', 'webmention' ); ?></label>
-<input type="text" class="widefat" disabled value="<?php echo get_comment_meta( $comment->comment_ID, 'webmention_target_fragment', true ); ?>" />
-<br />
-
 <label><?php esc_html_e( 'Webmention Source', 'webmention' ); ?></label>
 <input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $comment->comment_ID, 'webmention_source_url', true ); ?>" />
 <br />


### PR DESCRIPTION
This fixes the fact we had a template file, but were loading the template inside the class. It removes shwoing the fragment as this is only stored for querying. And it adds storing the protocol in the protocol field. Right now, we are using Semantic Linkbacks to change all replies to comments, and one of the early arguments was that this made it hard to determine original source. Also, this starts to put things in line with the upcoming plan to match the activitypub storage methodology.