### PR TITLE
Utilize Parsing

### DIFF
--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -553,7 +553,7 @@ class Webmention_Receiver {
 
 		// If this is an mf2 object store
 		if ( 'application/mf2+json' === $content_type ) {
-			$commentdata['remote_source_mf2'] = json_decode( $remote_source_original );
+			$commentdata['remote_source_mf2'] = json_decode( $remote_source_original, true );
 		}
 		if ( 'text/html' === $content_type ) {
 			// Pass the DOMDocument as it can be used to add additional properties should MF2 parsing not yield them

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -236,8 +236,7 @@ function webmention_discover_endpoint( $url ) {
 
 	libxml_use_internal_errors( true );
 
-	$doc = new DOMDocument();
-	$doc->loadHTML( $contents );
+	$doc = webmention_load_domdocument( $contents );
 
 	$xpath = new DOMXPath( $doc );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -320,6 +320,10 @@ endif;
 
 if ( ! function_exists( 'webmention_load_domdocument' ) ) :
 	function webmention_load_domdocument( $content ) {
+		$doc = apply_filters( 'webmention_load_domdocument', null, $content );
+		if ( $doc ) {
+			return $doc;
+		}
 		$doc = new DOMDocument();
 		libxml_use_internal_errors( true );
 		if ( function_exists( 'mb_convert_encoding' ) ) {


### PR DESCRIPTION
In the previous merge, we added PHP-MF2 into webmentions. In this PR, the system actually parses MF2 and passes it and the DOMDocument used to generate it into the $commendata array. The DOMDocument can be reused to parse title and other functions if there is no MF2 discovered, so there is no need to redo it.

In https://github.com/pfefferle/wordpress-semantic-linkbacks/pull/230 - Semantic Linkbacks looks for that same parsed MF2 and uses it if it is there. 

This also adds the filter discussed to pass in an alternative DOMDocument class.