### PR TITLE
Cache in cases where stored avatar is a gravatar

### DIFF
--- a/includes/class-webmention-avatar-handler.php
+++ b/includes/class-webmention-avatar-handler.php
@@ -83,8 +83,17 @@ class Webmention_Avatar_Handler {
 	 *
 	 * @return boolean
 	 */
-	public static function check_gravatar( $comment ) {
-		$hash  = md5( strtolower( trim( $comment->comment_author_email ) ) );
+	public static function check_gravatar( $comment, $args = null ) {
+		if ( ! empty( $comment->comment_author_email ) ) {
+			$hash = md5( strtolower( trim( $comment->comment_author_email ) ) );
+		} elseif ( is_array( $args ) && array_key_exists( 'url', $args ) ) {
+			if ( ! strpos( $args['url'], 'gravatar.com' ) ) {
+				return false;
+			}
+			$hash = wp_parse_url( $args['url'], PHP_URL_PATH );
+			$hash = str_replace( '/avatar/', '', $hash );
+		}
+
 		$found = get_transient( 'webmention_gravatar_' . $hash );
 
 		if ( false !== $found ) {
@@ -128,7 +137,7 @@ class Webmention_Avatar_Handler {
 			return $args;
 		}
 
-		if ( ! empty( $comment->comment_author_email ) && self::check_gravatar( $comment ) ) {
+		if ( self::check_gravatar( $comment, $args ) ) {
 			return $args;
 		}
 

--- a/includes/class-webmention-avatar-handler.php
+++ b/includes/class-webmention-avatar-handler.php
@@ -92,6 +92,8 @@ class Webmention_Avatar_Handler {
 			}
 			$hash = wp_parse_url( $args['url'], PHP_URL_PATH );
 			$hash = str_replace( '/avatar/', '', $hash );
+		} else {
+			return false;
 		}
 
 		$found = get_transient( 'webmention_gravatar_' . $hash );


### PR DESCRIPTION
Fixes #248 

This moves the checking for whether an email exists from the anoynmous code into the check_gravatar function. It also passes the arguments array, optionally in and checks to see if the URL passed in it is a gravatar URL. If so, it extracts the hash and runs the same check.

This should fix the problem.