### PR TITLE
Fix issue where comment type was not recognized

### DIFF
--- a/includes/class-webmention-avatar-handler.php
+++ b/includes/class-webmention-avatar-handler.php
@@ -168,7 +168,7 @@ class Webmention_Avatar_Handler {
 		}
 
 		// If this type does not show avatars or if there is a user ID set then return
-		if ( ! is_avatar_comment_type( $comment->comment_type ) || $comment->user_id ) {
+		if ( ! is_avatar_comment_type( get_comment_type( $comment ) ) || $comment->user_id ) {
 			return $args;
 		}
 


### PR DESCRIPTION
Still working on fixes for the avatar situation. Noticed another mistake here...since comment_type for comments is '', this wasn't recognizing comments as a comment type. Switched to get_comment_type that should be used.