### PR TITLE
Fix Comment Approval Alternate

### DIFF
--- a/includes/class-webmention-admin.php
+++ b/includes/class-webmention-admin.php
@@ -24,7 +24,7 @@ class Webmention_Admin {
 		add_filter( 'manage_comments_custom_column', array( 'Webmention_Admin', 'manage_comments_custom_column' ), 10, 2 );
 
 		add_filter( 'comment_row_actions', array( 'Webmention_Admin', 'comment_row_actions' ), 13, 2 );
-		add_filter( 'comment_unapproved_to_approved', array( 'Webmention_Admin', 'transition_to_whitelist' ), 10 );
+		add_filter( 'comment_unapproved_to_approved', array( 'Webmention_Admin', 'transition_to_approvelist' ), 10 );
 
 		self::add_privacy_policy_content();
 	}
@@ -177,20 +177,20 @@ class Webmention_Admin {
 
 		$status = wp_get_comment_status( $comment );
 		if ( 'unapproved' === $status ) {
-			$actions['domainwhitelist'] = sprintf( '<a href="%1$s" aria-label="%2$s">%2$s</a>', esc_url( $approve_url ), esc_attr__( 'Approve & Whitelist', 'webmention' ) );
+			$actions['domainapprovelist'] = sprintf( '<a href="%1$s" aria-label="%2$s">%2$s</a>', esc_url( $approve_url ), esc_attr__( 'Approve & Always Allow', 'webmention' ) );
 		}
 		return $actions;
 	}
 
 	public static function add_webmention_approve_domain( $host ) {
-		$whitelist   = get_webmention_approve_domains();
-		$whitelist[] = $host;
-		$whitelist   = array_unique( $whitelist );
-		$whitelist   = implode( "\n", $whitelist );
-		update_option( 'webmention_approve_domains', $whitelist );
+		$approvelist   = get_webmention_approve_domains();
+		$approvelist[] = $host;
+		$approvelist   = array_unique( $approvelist );
+		$approvelist   = implode( "\n", $approvelist );
+		update_option( 'webmention_approve_domains', $approvelist );
 	}
 
-	public static function transition_to_whitelist( $comment ) {
+	public static function transition_to_approvelist( $comment ) {
 		if ( ! current_user_can( 'moderate_comments' ) ) {
 			return;
 		}

--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -290,7 +290,7 @@ class Webmention_Receiver {
 		// change this if your theme can't handle the Webmentions comment type
 		$comment_type = WEBMENTION_COMMENT_TYPE;
 
-		$commentdata = compact( 'comment_type', 'comment_approved', 'comment_agent', 'comment_date', 'comment_date_gmt', 'comment_meta', 'source', 'target', 'vouch' );
+		$commentdata = compact( 'comment_type', 'comment_agent', 'comment_date', 'comment_date_gmt', 'comment_meta', 'source', 'target', 'vouch' );
 
 		$commentdata['comment_post_ID']   = $comment_post_id;
 		$commentdata['comment_author_IP'] = $comment_author_ip;

--- a/includes/class-webmention-receiver.php
+++ b/includes/class-webmention-receiver.php
@@ -33,7 +33,7 @@ class Webmention_Receiver {
 		add_filter( 'webmention_comment_data', array( 'Webmention_Receiver', 'default_title_filter' ), 21, 1 );
 		add_filter( 'webmention_comment_data', array( 'Webmention_Receiver', 'default_content_filter' ), 22, 1 );
 
-		add_filter( 'webmention_comment_data', array( 'Webmention_Receiver', 'auto_approve' ), 13, 1 );
+		add_filter( 'pre_comment_approved', array( 'Webmention_Receiver', 'auto_approve' ), 11, 2 );
 
 		// Allow for avatars on webmention comment types
 		if ( 0 !== (int) get_option( 'webmention_avatars', 1 ) ) {
@@ -289,9 +289,6 @@ class Webmention_Receiver {
 
 		// change this if your theme can't handle the Webmentions comment type
 		$comment_type = WEBMENTION_COMMENT_TYPE;
-
-		// change this if you want to auto approve your Webmentions
-		$comment_approved = WEBMENTION_COMMENT_APPROVE;
 
 		$commentdata = compact( 'comment_type', 'comment_approved', 'comment_agent', 'comment_date', 'comment_date_gmt', 'comment_meta', 'source', 'target', 'vouch' );
 
@@ -773,37 +770,49 @@ class Webmention_Receiver {
 	}
 
 	/**
-	 * Use the whitelist check function to approve a comment if the source domain is on the whitelist.
+	 * Use the approved check function to approve a comment if the source domain is on the approve list.
 	 *
+	 * @param int|string/WP_Error $approved The approval status. Accepts 1, 0, spam, or WP_Error.
 	 * @param array $commentdata
 	 *
 	 * @return array $commentdata
 	 */
-	public static function auto_approve( $commentdata ) {
-		if ( ! $commentdata || is_wp_error( $commentdata ) ) {
-			return $commentdata;
+	public static function auto_approve( $approved, $commentdata ) {
+		if ( is_wp_error( $approved ) ) {
+			return $approved;
 		}
-		if ( self::is_source_whitelisted( $commentdata['source'] ) ) {
-			$commentdata['comment_approved'] = 1;
+		// Exit if there is no source to investigate
+		if ( ! array_key_exists( 'source', $commentdata ) ) {
+			return $approved;
 		}
-		return $commentdata;
+		if ( array_key_exists( 'comment_meta', $commentdata ) ) {
+			if ( ! array_key_exists( 'protocol', $commentdata['comment_meta'] ) || 'webmention' !== $commentdata['comment_meta']['protocol'] ) {
+				return $approved;
+			}
+		}
+		// If this is set auto approve all webmentions
+		if ( 1 === WEBMENTION_COMMENT_APPROVE ) {
+			return 1;
+		}
+
+		return self::is_source_whitelisted( $commentdata['source'] ) ? 1 : 0;
 	}
 
 	/**
-	 * Check the source $url to see if it is on the domain whitelist.
+	 * Check the source $url to see if it is on the domain approve list.
 	 *
 	 * @param array $author_url
 	 *
 	 * @return boolean
 	 */
 	public static function is_source_whitelisted( $url ) {
-		$whitelist = get_webmention_approve_domains();
+		$approvelist = get_webmention_approve_domains();
 		$host      = webmention_extract_domain( $url );
-		if ( empty( $whitelist ) ) {
+		if ( empty( $approvelist ) ) {
 			return false;
 		}
 
-		foreach ( (array) $whitelist as $domain ) {
+		foreach ( (array) $approvelist as $domain ) {
 			$domain = trim( $domain );
 			if ( empty( $domain ) ) {
 				continue;

--- a/languages/webmention.pot
+++ b/languages/webmention.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: Webmention 4.0.2\n"
+"Project-Id-Version: Webmention 4.0.3\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wordpress-webmention\n"
-"POT-Creation-Date: 2020-01-08 18:27:01+00:00\n"
+"POT-Creation-Date: 2020-01-18 06:45:39+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,6 +13,26 @@ msgstr ""
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: grunt-wp-i18n 1.0.3\n"
+
+#: includes/class-linkback.php:61 includes/class-webmention-receiver.php:471
+msgid "Content Type is not supported"
+msgstr ""
+
+#: includes/class-linkback.php:73 includes/class-webmention-receiver.php:486
+msgid "Resource not found"
+msgstr ""
+
+#: includes/class-linkback.php:81
+msgid "HEAD not allowed"
+msgstr ""
+
+#: includes/class-linkback.php:89 includes/class-webmention-receiver.php:495
+msgid "Resource has been deleted"
+msgstr ""
+
+#: includes/class-linkback.php:97 includes/class-webmention-receiver.php:504
+msgid "Resource removed for legal reasons"
+msgstr ""
 
 #: includes/class-webmention-admin.php:14 templates/webmention-settings.php:2
 msgid "Webmention Settings"
@@ -58,7 +78,7 @@ msgid "Comment-Type"
 msgstr ""
 
 #: includes/class-webmention-admin.php:180
-msgid "Approve & Whitelist"
+msgid "Approve & Always Allow"
 msgstr ""
 
 #: includes/class-webmention-admin.php:248
@@ -309,44 +329,28 @@ msgstr ""
 msgid "Pings are disabled for this post"
 msgstr ""
 
-#: includes/class-webmention-receiver.php:336
+#: includes/class-webmention-receiver.php:333
 msgid "Webmention is scheduled"
 msgstr ""
 
-#: includes/class-webmention-receiver.php:410
+#: includes/class-webmention-receiver.php:407
 msgid "Webmention was successful"
 msgstr ""
 
-#: includes/class-webmention-receiver.php:441
+#: includes/class-webmention-receiver.php:438
 #: includes/class-webmention-vouch.php:58
 msgid "Invalid data passed"
 msgstr ""
 
-#: includes/class-webmention-receiver.php:460
+#: includes/class-webmention-receiver.php:457
 msgid "Source URL not found"
 msgstr ""
 
-#: includes/class-webmention-receiver.php:474
-msgid "Content Type is not supported"
-msgstr ""
-
-#: includes/class-webmention-receiver.php:489
-msgid "Resource not found"
-msgstr ""
-
-#: includes/class-webmention-receiver.php:498
-msgid "Resource has been deleted"
-msgstr ""
-
-#: includes/class-webmention-receiver.php:507
-msgid "Resource removed for legal reasons"
-msgstr ""
-
-#: includes/class-webmention-receiver.php:541
+#: includes/class-webmention-receiver.php:538
 msgid "Cannot find target link"
 msgstr ""
 
-#: includes/class-webmention-receiver.php:739
+#: includes/class-webmention-receiver.php:736
 #. translators: This post format was mentioned on this URL with this domain
 #. name
 msgid "This %1$s was mentioned on <a href=\"%2$s\">%3$s</a>"

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 **Tags:** webmention, pingback, trackback, linkback, indieweb, comment, response  
 **Requires at least:** 4.9  
 **Tested up to:** 5.3.2  
-**Stable tag:** 4.0.2  
+**Stable tag:** 4.0.3  
 **Requires PHP:** 5.6  
 **License:** MIT  
 **License URI:** https://opensource.org/licenses/MIT  
@@ -92,6 +92,10 @@ Webmention headers are only shown if webmentions are available for that particul
 ## Changelog ##
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+### 4.0.3 ###
+* Move comment approve list and auto approve to the `wp_allow_comment` function called by the `wp_new_comment` function. 
+* Minor fix to avatar function to account for the fact comments have an empty comment type
 
 ### 4.0.2 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://notiz.blog/donate/
 Tags: webmention, pingback, trackback, linkback, indieweb, comment, response
 Requires at least: 4.9
 Tested up to: 5.3.2
-Stable tag: 4.0.2
+Stable tag: 4.0.3
 Requires PHP: 5.6
 License: MIT
 License URI: https://opensource.org/licenses/MIT
@@ -90,6 +90,10 @@ Webmention headers are only shown if webmentions are available for that particul
 == Changelog ==
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+= 4.0.3 =
+* Move comment approve list and auto approve to the `wp_allow_comment` function called by the `wp_new_comment` function. 
+* Minor fix to avatar function to account for the fact comments have an empty comment type
 
 = 4.0.2 =
 

--- a/webmention.php
+++ b/webmention.php
@@ -5,7 +5,7 @@
  * Description: Webmention support for WordPress posts
  * Author: Matthias Pfefferle
  * Author URI: https://notiz.blog/
- * Version: 4.0.2
+ * Version: 4.0.3
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT
  * Text Domain: webmention


### PR DESCRIPTION
This addresses #252 and is an alternative to #254. Props to @jeremyfelt who identified that the issue is the wp_allow_comment function interfering even though the comment_approved is set.

Now, the WEBMENTION_COMMENT_APPROVE flag has been there for years, even before the domain approval list. So, something else we changed created this situation. Either way, moving both checks to wp_allow_comment seems more consistent with the flow of adding a comment than setting it earlier.

At the same time, addressed the issue re the term whitelist. I did not change the function name, as it might be called elsewhere, but did change everything else.

Also bumped version to 4.0.3 for easy release.