### PR TITLE
Don't parse empty content for URLs

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -327,6 +327,12 @@ endif;
  * @return array URLs found in passed string.
  */
 function webmention_extract_urls( $content, $support_media_urls = false ) {
+
+	// If no content is provided, do not attempt to parse it for URLs.
+	if ( '' === $content ) {
+		return array();
+	}
+
 	$doc   = webmention_load_domdocument( $content );
 	$xpath = new DOMXPath( $doc );
 


### PR DESCRIPTION
If the HTML for a front-end view is built from post meta, it is possible that the `post_content` field for a post is empty. If empty content is parsed via `DOMDocument`, a PHP warning is shown:

`DOMDocument::loadHTML(): Empty string supplied as input`

This change skips the extraction of URLs for empty content and returns an empty array instead.