### PR TITLE
Add functionality to register a webmention comment type

### DIFF
--- a/includes/class-webmention-admin.php
+++ b/includes/class-webmention-admin.php
@@ -129,11 +129,16 @@ class Webmention_Admin {
 	 *
 	 * @param array $types the different comment types
 	 *
-	 * @return array the filtert comment types
+	 * @return array the filtered comment types
 	 */
 	public static function comment_types_dropdown( $types ) {
-		$types['webmention'] = esc_html__( 'Webmentions', 'webmention' );
-
+		global $webmention_comment_types;
+		if ( ! is_array( $webmention_comment_types ) ) {
+			return $types;
+		}
+		foreach ( $webmention_comment_types as $comment_type_object ) {
+			$types[ $comment_type_object->name ] = esc_html( $comment_type_object->label );
+		}
 		return $types;
 	}
 

--- a/includes/class-webmention-comment-type.php
+++ b/includes/class-webmention-comment-type.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Comment Type Class
+ *
+ */
+
+/**
+ * Class used for interacting with comment types.
+ *
+ * @see register_webmention_comment_type()
+ */
+final class Webmention_Comment_Type {
+	/**
+	 * Comment type key.
+	 *
+	 * @var string $name
+	 */
+	public $name;
+
+	/**
+	 * Name of the comment type. Usually plural.
+	 *
+	 * @var string $label
+	 */
+	public $label;
+
+
+	/**
+	 * Name of the comment type. Usually plural.
+	 *
+	 * @var string $singular
+	 */
+	public $singular;
+
+	/**
+	 * A short descriptive summary of what the comment type is.
+	 *
+	 * Default empty.
+	 *
+	 * @var string $description
+	 */
+	public $description = '';
+
+	/**
+	 * Constructor.
+	 *
+	 * Will populate object properties from the provided arguments and assign other
+	 * default properties based on that information.
+	 *
+	 *
+	 * @see register_webmention_comment_type()
+	 *
+	 * @param string       $post_type Post type key.
+	 * @param array|string $args      Optional. Array or string of arguments for registering a post type.
+	 *                                Default empty array.
+	 */
+	public function __construct( $post_type, $args = array() ) {
+		$this->name = $post_type;
+
+		$this->set_props( $args );
+	}
+
+	/**
+	 * Sets comment type properties.
+	 *
+	 * @param array|string $args Array or string of arguments for registering a comment type.
+	 */
+	public function set_props( $args ) {
+		$args = wp_parse_args( $args );
+
+		/**
+		 * Filters the arguments for registering a comment type.
+		 *
+		 * @param array  $args      Array of arguments for registering a comment type.
+		 * @param string $comment_type Comment type key.
+		 */
+		$args = apply_filters( 'register_webmention_comment_type_args', $args, $this->name );
+
+		// Args prefixed with an underscore are reserved for internal use.
+		$defaults = array(
+			'description' => '',
+		);
+
+		$args = array_merge( $defaults, $args );
+
+		$args['name'] = $this->name;
+
+		foreach ( $args as $property_name => $property_value ) {
+			$this->$property_name = $property_value;
+		}
+	}
+}

--- a/includes/class-webmention-comment-type.php
+++ b/includes/class-webmention-comment-type.php
@@ -57,7 +57,7 @@ final class Webmention_Comment_Type {
 	public function __construct( $post_type, $args = array() ) {
 		$this->name = $post_type;
 
-		$this->set_props( $args );
+		$this->set_properties( $args );
 	}
 
 	/**
@@ -65,7 +65,7 @@ final class Webmention_Comment_Type {
 	 *
 	 * @param array|string $args Array or string of arguments for registering a comment type.
 	 */
-	public function set_props( $args ) {
+	public function set_properties( $args ) {
 		$args = wp_parse_args( $args );
 
 		/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -416,7 +416,7 @@ function webmention_extract_urls( $content, $support_media_urls = false ) {
 }
 
 
-/*
+/**
  * Returns whether this is a webmention comment type
  * @param int|WP_Comment $comment
  * @return array
@@ -431,11 +431,11 @@ function is_webmention_comment_type( $comment ) {
 
 }
 
-/*
+/**
  * Returns a string indicating the comment type
  * @param int|WP_Comment $comment
  * @return string
-*/
+ */
 function get_webmention_comment_type_string( $comment ) {
 	global $webmention_comment_types;
 	$comment = get_comment( $comment );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -349,7 +349,7 @@ if ( ! function_exists( 'get_self_link' ) ) :
 	 * @return string Correct link for the atom:self element.
 	 */
 	function get_self_link() {
-		$host = @parse_url( home_url() );
+		$host = wp_parse_url( home_url() );
 		return set_url_scheme( 'http://' . $host['host'] . wp_unslash( $_SERVER['REQUEST_URI'] ) );
 	}
 endif;
@@ -420,14 +420,14 @@ function webmention_extract_urls( $content, $support_media_urls = false ) {
  * Returns whether this is a webmention comment type
  * @param int|WP_Comment $comment
  * @return array
-*/
+ */
 function is_webmention_comment_type( $comment ) {
 	$comment = get_comment( $comment );
 	if ( ! $comment ) {
 		return false;
 	}
 	$types = array( apply_filters( 'webmention_comment_type', WEBMENTION_COMMENT_TYPE ) );
-	return in_array( $comment->comment_type, $types );
+	return in_array( $comment->comment_type, $types, true );
 
 }
 

--- a/webmention.php
+++ b/webmention.php
@@ -44,6 +44,9 @@ function webmention_init() {
 		require_once dirname( __FILE__ ) . '/includes/debug.php';
 	}
 
+	// Comment Type Class
+	require_once dirname( __FILE__ ) . '/includes/class-webmention-comment-type.php';
+
 	// list of various public helper functions.
 	require_once dirname( __FILE__ ) . '/includes/functions.php';
 
@@ -89,6 +92,7 @@ function webmention_init() {
 	// remove old Webmention code.
 	remove_action( 'init', array( 'WebMentionFormPlugin', 'init' ) );
 	remove_action( 'init', array( 'WebMentionForCommentsPlugin', 'init' ) );
+
 }
 add_action( 'plugins_loaded', 'webmention_init' );
 


### PR DESCRIPTION
The idea here is a simple registration class for the webmention comment types based on the register_post_type function. 

So far, it incorporates the strings used for the various internal labels and menus, but eventually would add others as needed.

Essentially, it is an alternative to adding strings in five different places when adding a new type. And it will make it easier to add additional configuration options as needed.

If WordPress ever adds its own comment type registration, this would replace that.