### PR TITLE
Create class-webmention-request.php

### DIFF
--- a/includes/class-webmention-request.php
+++ b/includes/class-webmention-request.php
@@ -37,7 +37,7 @@ class Webmention_Request_Handler {
 			$response = wp_remote_get( $url, $args );
 		}
 		if ( is_wp_error( $response ) ) {
-				return $response;
+			return $response;
 		}
 		$check = $this->check_response_code( wp_remote_retrieve_response_code( $response ) );
 		if ( is_wp_error( $check ) ) {

--- a/includes/class-webmention-request.php
+++ b/includes/class-webmention-request.php
@@ -211,7 +211,7 @@ class Webmention_Request {
 	 *
 	 * @return array
 	 */
-	private function get_remote_arguments() {
+	protected function get_remote_arguments() {
 
 		$wp_version = get_bloginfo( 'version' );
 		$user_agent = apply_filters( 'http_headers_useragent', 'WordPress/' . $wp_version . '; ' . get_bloginfo( 'url' ) );
@@ -233,7 +233,7 @@ class Webmention_Request {
 	 *
 	 * @return WP_Error|true return an error or that something is supported
 	 */
-	private function check_content_type( $content_type ) {
+	protected function check_content_type( $content_type ) {
 		// not an (x)html, sgml, or xml page, no use going further
 		if ( preg_match( '#(image|audio|video|model)/#is', $content_type ) ) {
 			return new WP_Error(
@@ -254,7 +254,7 @@ class Webmention_Request {
 	 *
 	 * @return WP_Error|true return an error or that something is supported
 	 */
-	private function check_response_code( $code ) {
+	protected function check_response_code( $code ) {
 		switch ( $code ) {
 			case 200:
 				return true;
@@ -309,7 +309,7 @@ class Webmention_Request {
 	 * @return string|false return either false or the stripped string
 	 *
 	 */
-	private function get_content_type( $response ) {
+	protected function get_content_type( $response ) {
 		$content_type = wp_remote_retrieve_header( $response, 'Content-Type' );
 		// Strip any character set off the content type
 		$ct = explode( ';', $content_type );

--- a/includes/class-webmention-request.php
+++ b/includes/class-webmention-request.php
@@ -32,6 +32,24 @@ class Webmention_Request_Handler {
 	 * @var int
 	 */
 	public $response_code;
+	/**
+	 * Magic function for getter/setter
+	 *
+	 * @param string $method
+	 * @param array  $params
+	 * @return void
+	 */
+	public function __call( $method, $params ) {
+		$var = \strtolower( \substr( $method, 4 ) );
+
+		if ( \strncasecmp( $method, 'get', 3 ) === 0 ) {
+			return $this->$var;
+		}
+
+		if ( \strncasecmp( $method, 'set', 3 ) === 0 ) {
+			$this->$var = $params[0];
+		}
+	}
 
 	/**
 	 *  Retrieve a URL.

--- a/includes/class-webmention-request.php
+++ b/includes/class-webmention-request.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Encapsulates all Webmention HTTP requests
+ */
+class Webmention_Request_Handler {
+	/**
+	 *  Retrieve a URL.
+	 *
+	 * @param string $url The URL to retrieve.
+	 * @param boolean $safe Whether to use the safe or unfiltered version of HTTP API.
+	 *
+	 * @return WP_Error|array Either an error or the complete return object
+	 */
+	public function fetch( $url, $safe = true ) {
+		$response = $this->head( $url, $safe );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		$response = $this->fetch( $url, $safe );
+
+		return $response;
+	}
+
+	/**
+	 *  Retrieve a URL.
+	 *
+	 * @param string $url The URL to retrieve.
+	 * @param boolean $safe Whether to use the safe or unfiltered version of HTTP API.
+	 *
+	 * @return WP_Error|array Either an error or the complete return object
+	 */
+	public function get( $url, $safe = true ) {
+		$args = $this->get_remote_arguments();
+		if ( $safe ) {
+			$response = wp_safe_remote_get( $url, $args );
+		} else {
+			$response = wp_remote_get( $url, $args );
+		}
+		if ( is_wp_error( $response ) ) {
+				return $response;
+		}
+		$check = $this->check_response_code( wp_remote_retrieve_response_code( $response ) );
+		if ( is_wp_error( $check ) ) {
+				return $check;
+		}
+		$check = $this->check_content_type( wp_remote_retrieve_header( $response, 'content-type' ) );
+		if ( is_wp_error( $check ) ) {
+			return $check;
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Do a head request to check the suitability of a URL
+	 *
+	 * @param string $url The URL to check.
+	 * @param boolean $safe Whether to use the safe or unfiltered version of HTTP API.
+	 *
+	 * @return WP_Error|array Return error or HTTP API response array.
+	 */
+	public function head( $url, $safe = true ) {
+		$args = $this->get_remote_arguments();
+		if ( $safe ) {
+			$response = wp_safe_remote_head( $url, $args );
+		} else {
+			$response = wp_remote_head( $url, $args );
+		}
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		$check = $this->check_response_code( wp_remote_retrieve_response_code( $response ) );
+		if ( is_wp_error( $check ) ) {
+			return $check;
+		}
+		$check = $this->check_content_type( wp_remote_retrieve_header( $response, 'content-type' ) );
+		if ( is_wp_error( $check ) ) {
+			return $check;
+		}
+		return $response;
+	}
+
+	/**
+	 * Return Arguments for Retrieving Webmention URLs
+	 *
+	 * @return array
+	 */
+	public function get_remote_arguments() {
+
+		$wp_version = get_bloginfo( 'version' );
+		$user_agent = apply_filters( 'http_headers_useragent', 'WordPress/' . $wp_version . '; ' . get_bloginfo( 'url' ) );
+		$args       = array(
+			'timeout'             => 100,
+			'limit_response_size' => 153600,
+			'redirection'         => 20,
+			'headers'             => array(
+				'Accept' => 'text/html, text/plain',
+			),
+		);
+		return apply_filters( 'webmention_remote_get_args', $args );
+	}
+
+	/**
+	 * Check if response is a supportted content type
+	 *
+	 * @param  string $content_type The content type
+	 *
+	 * @return WP_Error|true return an error or that something is supported
+	 */
+	public function check_content_type( $content_type ) {
+		// not an (x)html, sgml, or xml page, no use going further
+		if ( preg_match( '#(image|audio|video|model)/#is', $content_type ) ) {
+			return new WP_Error(
+				'unsupported_content_type',
+				__( 'Content Type is not supported', 'webmention' ),
+				array(
+					'status' => 400,
+				)
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Check if response is a supported content type
+	 *
+	 * @param int $code Status Code.
+	 *
+	 * @return WP_Error|true return an error or that something is supported
+	 */
+	public function check_response_code( $code ) {
+		switch ( $code ) {
+			case 200:
+				return true;
+			case 404:
+				return new WP_Error(
+					'resource_not_found',
+					__( 'Resource not found', 'webmention' ),
+					array(
+						'status' => 400,
+					)
+				);
+			case 405:
+				return new WP_Error(
+					'method_not_allowed',
+					__( 'Method not allowed', 'webmention' ),
+					array(
+						'status' => 400,
+						'allow'  => wp_remote_retrieve_header( $response, 'allow' ),
+					)
+				);
+			case 410:
+				return new WP_Error(
+					'resource_deleted',
+					__( 'Resource has been deleted', 'webmention' ),
+					array(
+						'status' => 400,
+					)
+				);
+			case 452:
+				return new WP_Error(
+					'resource_removed',
+					__( 'Resource removed for legal reasons', 'webmention' ),
+					array(
+						'status' => 400,
+					)
+				);
+			default:
+				return new WP_Error(
+					'source_error',
+					wp_remote_retrieve_response_message( $response ),
+					array(
+						'status' => 400,
+					)
+				);
+		}
+	}
+
+	/**
+	 * Strip charset off content type for matching purposes
+	 * @param array $response HTTP_Response array
+	 *
+	 * @return string|false return either false or the stripped string
+	 *
+	 */
+	public function get_content_type( $response ) {
+		$content_type = wp_remote_retrieve_header( $response, 'Content-Type' );
+		// Strip any character set off the content type
+		$ct = explode( ';', $content_type );
+		if ( is_array( $ct ) ) {
+			$content_type = array_shift( $ct );
+		}
+		return trim( $content_type );
+	}
+
+	/**
+	 * Implement vouch verify here
+	 *
+	 * @return void
+	 */
+	public function verify() {
+		// @todo move verify code here
+	}
+}

--- a/includes/class-webmention-request.php
+++ b/includes/class-webmention-request.php
@@ -9,14 +9,14 @@ class Webmention_Request {
 	 *
 	 * @var string
 	 */
-	public $url;
+	protected $url;
 
 	/**
 	 * Body.
 	 *
 	 * @var string
 	 */
-	public $body;
+	protected $body;
 
 
 	/**
@@ -24,14 +24,15 @@ class Webmention_Request {
 	 *
 	 * @var string
 	 */
-	public $content_type;
+	protected $content_type;
 
 	/**
 	 * URL.
 	 *
 	 * @var int
 	 */
-	public $response_code;
+	protected $response_code;
+
 	/**
 	 * Magic function for getter/setter
 	 *

--- a/includes/class-webmention-request.php
+++ b/includes/class-webmention-request.php
@@ -2,7 +2,7 @@
 /**
  * Encapsulates all Webmention HTTP requests
  */
-class Webmention_Request_Handler {
+class Webmention_Request {
 
 	/**
 	 * URL.

--- a/includes/class-webmention-request.php
+++ b/includes/class-webmention-request.php
@@ -149,7 +149,7 @@ class Webmention_Request {
 	 *
 	 * @return WP_Error|array Either an error or the complete return object
 	 */
-	private function get( $url, $safe = true ) {
+	public function get( $url, $safe = true ) {
 		$args = $this->get_remote_arguments();
 		if ( $safe ) {
 			$response = wp_safe_remote_get( $url, $args );
@@ -184,7 +184,7 @@ class Webmention_Request {
 	 *
 	 * @return WP_Error|array Return error or HTTP API response array.
 	 */
-	private function head( $url, $safe = true ) {
+	public function head( $url, $safe = true ) {
 		$args = $this->get_remote_arguments();
 		if ( $safe ) {
 			$response = wp_safe_remote_head( $url, $args );

--- a/includes/class-webmention-request.php
+++ b/includes/class-webmention-request.php
@@ -16,7 +16,7 @@ class Webmention_Request_Handler {
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
-		$response = $this->fetch( $url, $safe );
+		$response = $this->get( $url, $safe );
 
 		return $response;
 	}
@@ -191,14 +191,5 @@ class Webmention_Request_Handler {
 			$content_type = array_shift( $ct );
 		}
 		return trim( $content_type );
-	}
-
-	/**
-	 * Implement vouch verify here
-	 *
-	 * @return void
-	 */
-	public function verify() {
-		// @todo move verify code here
 	}
 }


### PR DESCRIPTION
I would love to simplify things, because the code is getting larger and larger.

I would love to have some very simple methods, to return the HTML and the correct parsed MF2 or directly the prefilled comment.

Something like:

```PHP
$request = new Webmention_Request();
$response = $request-fetch( $url );

if ( is_wp_error( $response ) ) {
	return $response;
}
$mf2_handler = new Webmention_Mf2_Handler();
$mf2_handler->parse( $response->get_body(), $url );
$mf2_handler->prefill_comment();
```

In this case it is very easy to use the code for the admin debug endpoint, for the direct parsing and the scheduled parsing.

I would love to work on this one first, so that we can use the request object and adapt the changes for the #247 change.

Perhaps we could also add the send webmention code to this class.

@dshanske what do you think?

@dshanske please commit directly to this branch if you like the idea.