### PR TITLE
Change priority of publish hook

### DIFF
--- a/includes/class-webmention-sender.php
+++ b/includes/class-webmention-sender.php
@@ -19,7 +19,7 @@ class Webmention_Sender {
 		// Send Webmentions from Every Type that Declared Webmention Support
 		$post_types = get_post_types_by_support( 'webmentions' );
 		foreach ( $post_types as $post_type ) {
-			add_action( 'publish_' . $post_type, array( 'Webmention_Sender', 'publish_hook' ) );
+			add_action( 'publish_' . $post_type, array( 'Webmention_Sender', 'publish_hook' ), 3 );
 		}
 
 		add_action( 'comment_post', array( 'Webmention_Sender', 'comment_post' ) );


### PR DESCRIPTION
Had a look at core.

https://github.com/WordPress/WordPress/blob/3dda74c3377243797ceffb429f94e0ea63ad6d75/wp-includes/default-filters.php#L358

The _publish_post_hook is at priority 5.

https://github.com/WordPress/WordPress/blob/3da046e1bce8408a1b6cd08e03eaf69a6bb506cd/wp-includes/post.php#L7029

The function is what triggers do_pings. So _mentionme should be added before this is scheduled. And it is scheduled to occur immediately at priority 5. So the webmention trigger should be ahead of that at 3 or 4. 