### PR TITLE
Fix issue with response not being passed to response code.

### DIFF
--- a/includes/class-webmention-request.php
+++ b/includes/class-webmention-request.php
@@ -92,7 +92,7 @@ class Webmention_Request {
 			return $response;
 		}
 
-		$check = $this->check_response_code( wp_remote_retrieve_response_code( $response ) );
+		$check = $this->check_response_code( wp_remote_retrieve_response_code( $response ), $response );
 		if ( is_wp_error( $check ) ) {
 				return $check;
 		}
@@ -127,7 +127,7 @@ class Webmention_Request {
 			return $response;
 		}
 		$this->response_code = wp_remote_retrieve_response_code( $response );
-		$check               = $this->check_response_code( $this->response_code );
+		$check               = $this->check_response_code( $this->response_code, $response );
 		if ( is_wp_error( $check ) ) {
 			return $check;
 		}
@@ -183,10 +183,11 @@ class Webmention_Request {
 	 * Check if response is a supported content type
 	 *
 	 * @param int $code Status Code.
+	 * @param array $response Response if Present
 	 *
 	 * @return WP_Error|true return an error or that something is supported
 	 */
-	protected function check_response_code( $code ) {
+	protected function check_response_code( $code, $response = null ) {
 		switch ( $code ) {
 			case 200:
 				return true;


### PR DESCRIPTION
https://wordpress.org/support/topic/error-cannot-find-target-link/

The error isn't related to specifically to what was reported, but it reveals a mistake in not passing the response variable optionally to be used.