### PR TITLE
Comment form template: add hooks before and after the form

### DIFF
--- a/templates/webmention-comment-form.php
+++ b/templates/webmention-comment-form.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * Hook to add custom content before the webmention form added to the comment form.
+ */
+do_action( 'webmention_comment_form_template_start' );
+?>
 <form id="webmention-form" action="<?php echo get_webmention_endpoint(); ?>" method="post">
 	<p>
 		<label for="webmention-source"><?php echo get_webmention_form_text( get_the_ID() ); ?></label>
@@ -11,3 +17,9 @@
 	<input id="webmention-format" type="hidden" name="format" value="html" />
 	<input id="webmention-target" type="hidden" name="target" value="<?php the_permalink(); ?>" />
 </form>
+<?php
+/**
+ * Hook to add custom content after the webmention form added to the comment form.
+ */
+do_action( 'webmention_comment_form_template_end' );
+?>

--- a/templates/webmention-comment-form.php
+++ b/templates/webmention-comment-form.php
@@ -2,7 +2,7 @@
 /**
  * Hook to add custom content before the webmention form added to the comment form.
  */
-do_action( 'webmention_comment_form_template_start' );
+do_action( 'webmention_comment_form_template_before' );
 ?>
 <form id="webmention-form" action="<?php echo get_webmention_endpoint(); ?>" method="post">
 	<p>
@@ -21,5 +21,5 @@ do_action( 'webmention_comment_form_template_start' );
 /**
  * Hook to add custom content after the webmention form added to the comment form.
  */
-do_action( 'webmention_comment_form_template_end' );
+do_action( 'webmention_comment_form_template_after' );
 ?>


### PR DESCRIPTION
Would you be open to adding hooks in the different templates available in the plugin?  This would allow one to add content before or after the webmention form, without having to overwrite the full template.

For example, one could add an HTML element between the comment form and the webmention form, without having to rely on custom CSS or having to define their own custom `templates/webmention-comment-form.php` via the existing `webmention_comment_form` filter.

```php
add_action(
	'webmention_comment_form_template_before',
	function () {
		echo '<hr class="styled-separator is-style-wide" aria-hidden="true">';
	}
);
```

What do you think?