### PR TITLE
Fixes an Issue in Comment Types

### DIFF
--- a/includes/class-comment-type.php
+++ b/includes/class-comment-type.php
@@ -26,7 +26,7 @@ final class Comment_Type {
 	public $label;
 
 	/**
-	 * Name of the comment type. Usually plural.
+	 * Name of the comment type. Singular.
 	 *
 	 * @var string $singular
 	 */

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -24,7 +24,8 @@ class Comment {
 		register_webmention_comment_type(
 			'repost',
 			array(
-				'label'       => __( 'Repost', 'webmention' ),
+				'label'       => __( 'Reposts', 'webmention' ),
+				'singular'       => __( 'Repost', 'webmention' ),
 				'description' => __( 'A repost on the indieweb is a post that is purely a 100% re-publication of another (typically someone else\'s) post.', 'webmention' ),
 				'icon'        => '♺',
 				// translators: %1$s username, %2$s opject format (post, audio, ...), %3$s URL, %4$s domain
@@ -35,8 +36,9 @@ class Comment {
 		register_webmention_comment_type(
 			'like',
 			array(
-				'label'       => __( 'Like', 'webmention' ),
-				'description' => __( 'Like', 'webmention' ),
+				'label'       => __( 'Likes', 'webmention' ),
+				'singular'       => __( 'Like', 'webmention' ),
+				'description' => __( 'A like is a popular webaction button and in some cases post type on various silos such as Facebook and Instagram.', 'webmention' ),
 				'icon'        => '👍',
 				// translators: %1$s username, %2$s opject format (post, audio, ...), %3$s URL, %4$s domain
 				'excerpt'     => __( '%1$s liked %2$s on <a href="%3$s">%4$s</a>.', 'webmention' ),
@@ -46,7 +48,8 @@ class Comment {
 		register_webmention_comment_type(
 			'favorite',
 			array(
-				'label'       => __( 'Favorite', 'webmention' ),
+				'label'       => __( 'Favorites', 'webmention' ),
+				'singular'       => __( 'Favorite', 'webmention' ),
 				'description' => __( 'A favorite is a common webaction on many silos (like Flickr, Twitter), typically visually indicated with a star symbol that fills in with a color when activated (pink, orange).', 'webmention' ),
 				'icon'        => '⭐',
 				// translators: %1$s username, %2$s opject format (post, audio, ...), %3$s URL, %4$s domain
@@ -57,7 +60,8 @@ class Comment {
 		register_webmention_comment_type(
 			'tag',
 			array(
-				'label'       => __( 'Tag', 'webmention' ),
+				'label'       => __( 'Tags', 'webmention' ),
+				'singular'       => __( 'Tag', 'webmention' ),
 				'description' => __( 'Tags or tagging refers to categorizing or labeling content, your own or others (tag-reply), with words, phrases, names, or other information, optionally linked to specific people, events, locations, such as the practice of tagging posts being about certain people (person-tag), like tagging people or other items where (area-tag) they\'re depicted in a photo.', 'webmention' ),
 				'icon'        => '📌',
 				// translators: %1$s username, %2$s opject format (post, audio, ...), %3$s URL, %4$s domain
@@ -68,7 +72,8 @@ class Comment {
 		register_webmention_comment_type(
 			'bookmark',
 			array(
-				'label'       => __( 'Bookmark', 'webmention' ),
+				'label'       => __( 'Bookmarks', 'webmention' ),
+				'singular'       => __( 'Bookmark', 'webmention' ),
 				'description' => __( 'A bookmark (or linkblog) is a post that is primarily comprised of a URL, often title text from that URL, sometimes optional text describing, tagging, or quoting from its contents.', 'webmention' ),
 				'icon'        => '🔖',
 				// translators: %1$s username, %2$s opject format (post, audio, ...), %3$s URL, %4$s domain
@@ -79,7 +84,8 @@ class Comment {
 		register_webmention_comment_type(
 			'listen',
 			array(
-				'label'       => __( 'Listen', 'webmention' ),
+				'label'       => __( 'Listens', 'webmention' ),
+				'singular'       => __( 'Listen', 'webmention' ),
 				'description' => __( 'A "listen" is a passive type of post used to publish a song (music or audio track, including concert recordings or DJ sets) or podcast that you have listened to.', 'webmention' ),
 				'icon'        => '🎧',
 				// translators: %1$s username, %2$s opject format (post, audio, ...), %3$s URL, %4$s domain
@@ -90,7 +96,8 @@ class Comment {
 		register_webmention_comment_type(
 			'watch',
 			array(
-				'label'       => __( 'Watch', 'webmention' ),
+				'label'       => __( 'Watches', 'webmention' ),
+				'singular'       => __( 'Watch', 'webmention' ),
 				'description' => __( 'A watch is a semi-passive type of post used to publish that you have watched a video (movie, TV, film), or a live show (theater, concert).', 'webmention' ),
 				'icon'        => '📺',
 				// translators: %1$s username, %2$s opject format (post, audio, ...), %3$s URL, %4$s domain
@@ -101,7 +108,8 @@ class Comment {
 		register_webmention_comment_type(
 			'read',
 			array(
-				'label'       => __( 'Read', 'webmention' ),
+				'label'       => __( 'Reads', 'webmention' ),
+				'singular'       => __( 'Read', 'webmention' ),
 				'icon'        => '📖',
 				'description' => __( 'To read or reading is the act of viewing and interpreting posts or other documents; on the IndieWeb, a read post expresses that something has been read, like a book or section thereof.', 'webmention' ),
 				// translators: %1$s username, %2$s opject format (post, audio, ...), %3$s URL, %4$s domain
@@ -112,7 +120,8 @@ class Comment {
 		register_webmention_comment_type(
 			'follow',
 			array(
-				'label'       => __( 'Follow', 'webmention' ),
+				'label'       => __( 'Follows', 'webmention' ),
+				'singular'       => __( 'Follow', 'webmention' ),
 				'description' => __( 'Follow is a common feature (and often UI button) in silo UIs (like Twitter) that adds updates from that profile (typically a person) to the stream shown in an integrated reader, and sometimes creates a follow post either in the follower\'s stream ("… followed …" or "… is following …") thus visible to their followers, and/or in the notifications of the user being followed ("… followed you").', 'webmention' ),
 				'icon'        => '👣',
 				// translators: %1$s username, %2$s opject format (post, audio, ...), %3$s URL, %4$s domain
@@ -123,7 +132,8 @@ class Comment {
 		register_webmention_comment_type(
 			'reacji',
 			array(
-				'label'       => __( 'Reacji', 'webmention' ),
+				'label'       => __( 'Reacjis', 'webmention' ),
+				'singular'       => __( 'Reacji', 'webmention' ),
 				'description' => __( 'Reacji is an emoji reaction, the use of a single emoji character in response to a post,', 'webmention' ),
 				'excerpt'     => '%s',
 			)

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Tags:** webmention, pingback, trackback, linkback, indieweb, comment, response  
 **Requires at least:** 4.9  
 **Tested up to:** 5.9  
-**Stable tag:** 4.0.4  
+**Stable tag:** 5.0.0  
 **Requires PHP:** 5.6  
 **License:** MIT  
 **License URI:** https://opensource.org/licenses/MIT  
@@ -18,7 +18,7 @@ A [Webmention](https://www.w3.org/TR/webmention/) is a notification that one URL
 
 For example, a response can be an RSVP to an event, an indication that someone "likes" another post, a "bookmark" of another post, and many others. Webmention enables these interactions to happen across different websites, enabling a distributed social web.
 
-The Webmention plugin supports the webmention protocol, giving you support for sending and receiving webmentions. It offers a simple built in presentation. To further enhance the presentation, you can install Semantic Linkbacks.
+The Webmention plugin supports the webmention protocol, giving you support for sending and receiving webmentions. It offers a simple built in presentation.
 
 ## Frequently Asked Questions ##
 
@@ -75,7 +75,7 @@ As Webmention uses the REST API endpoint system, most up to date caching plugins
 
 ### Why does this plugin have settings about avatars? ###
 
-Webmentions have the ability to act as rich comments. This includes showing avatars. If there is an avatar discovered, the URL for it will be stored in comment meta. This can either be reflect something from the media library or a URL of a file.
+Webmentions have the ability to act as rich comments. This includes showing avatars. If there is an avatar discovered, the URL for it will be stored. This can either be reflect something from the media library or a URL of a file.
 
 Since webmentions do not usually have email addresses, Gravatar, built into WordPress, is not necessary. WordPress returns even the anonymous avatars from Gravatar. Therefore, if there is no email the plugin will simply return a local copy of the Mystery Man default avatar. If there is an email address, the plugin will cache whether a Gravatar exists and serve the local file if it does not. It defaults to a week, but you can change it to a day, or any number by adding below to your wp-config.php file.
 
@@ -90,6 +90,15 @@ Webmention headers are only shown if webmentions are available for that particul
 ## Changelog ##
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+### 5.0.0 ###
+
+* Complete rewrite of the codebase
+* Introduce PHP namespaces
+* New parser which will fallback on the WordPress REST API, JSON-LD, or HTML meta tags if Microformats are not sufficient to render a comment.
+* New debugger/test tool for Webmention Parsing under Tools
+* Webmentions are no longer stored as comment type mention, but as custom comment types
+* New simplified presentation code, providing for optional custom templating in future.
 
 ### 4.0.4 ###
 
@@ -385,6 +394,12 @@ To install a WordPress Plugin manually:
 * Click **Activate** to activate it.
 
 ## Upgrade Notice ##
+
+### 5.0.0 ###
+
+This version is a complete rewrite of the code and a merge of the Semantic Linkbacks plugin. You should uninstall Semantic Linkbacks for this upgrade. Please file upgrade issues via Github.
+
+Warning: Please backup your database before upgrading. This version changes the storage method of webmentions.
 
 ### 3.0.0 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://notiz.blog/donate/
 Tags: webmention, pingback, trackback, linkback, indieweb, comment, response
 Requires at least: 4.9
 Tested up to: 5.9
-Stable tag: 4.0.4
+Stable tag: 5.0.0
 Requires PHP: 5.6
 License: MIT
 License URI: https://opensource.org/licenses/MIT
@@ -18,7 +18,7 @@ A [Webmention](https://www.w3.org/TR/webmention/) is a notification that one URL
 
 For example, a response can be an RSVP to an event, an indication that someone "likes" another post, a "bookmark" of another post, and many others. Webmention enables these interactions to happen across different websites, enabling a distributed social web.
 
-The Webmention plugin supports the webmention protocol, giving you support for sending and receiving webmentions. It offers a simple built in presentation. To further enhance the presentation, you can install Semantic Linkbacks.
+The Webmention plugin supports the webmention protocol, giving you support for sending and receiving webmentions. It offers a simple built in presentation.
 
 == Frequently Asked Questions ==
 
@@ -75,7 +75,7 @@ As Webmention uses the REST API endpoint system, most up to date caching plugins
 
 = Why does this plugin have settings about avatars? =
 
-Webmentions have the ability to act as rich comments. This includes showing avatars. If there is an avatar discovered, the URL for it will be stored in comment meta. This can either be reflect something from the media library or a URL of a file.
+Webmentions have the ability to act as rich comments. This includes showing avatars. If there is an avatar discovered, the URL for it will be stored. This can either be reflect something from the media library or a URL of a file.
 
 Since webmentions do not usually have email addresses, Gravatar, built into WordPress, is not necessary. WordPress returns even the anonymous avatars from Gravatar. Therefore, if there is no email the plugin will simply return a local copy of the Mystery Man default avatar. If there is an email address, the plugin will cache whether a Gravatar exists and serve the local file if it does not. It defaults to a week, but you can change it to a day, or any number by adding below to your wp-config.php file.
 
@@ -90,6 +90,15 @@ Webmention headers are only shown if webmentions are available for that particul
 == Changelog ==
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+= 5.0.0 =
+
+* Complete rewrite of the codebase
+* Introduce PHP namespaces
+* New parser which will fallback on the WordPress REST API, JSON-LD, or HTML meta tags if Microformats are not sufficient to render a comment.
+* New debugger/test tool for Webmention Parsing under Tools
+* Webmentions are no longer stored as comment type mention, but as custom comment types
+* New simplified presentation code, providing for optional custom templating in future.
 
 = 4.0.4 =
 
@@ -385,6 +394,12 @@ To install a WordPress Plugin manually:
 * Click **Activate** to activate it.
 
 == Upgrade Notice ==
+
+= 5.0.0 =
+
+This version is a complete rewrite of the code and a merge of the Semantic Linkbacks plugin. You should uninstall Semantic Linkbacks for this upgrade. Please file upgrade issues via Github.
+
+Warning: Please backup your database before upgrading. This version changes the storage method of webmentions.
 
 = 3.0.0 =
 

--- a/webmention.php
+++ b/webmention.php
@@ -5,7 +5,7 @@
  * Description: Webmention support for WordPress posts
  * Author: Matthias Pfefferle
  * Author URI: https://notiz.blog/
- * Version: 5.X
+ * Version: 5.0.0
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT
  * Text Domain: webmention


### PR DESCRIPTION
Started doing some user testing on a live test site and noticed this bug with the comment types. We never set the singular property and that is used in the Comment Admin screen.