### PR TITLE
Use available `$vouch` instead of `$params['vouch']`

### DIFF
--- a/includes/class-receiver.php
+++ b/includes/class-receiver.php
@@ -246,7 +246,7 @@ class Receiver {
 
 		if ( $vouch ) {
 			// If there is a vouch pass it along
-			$vouch = urldecode( $params['vouch'] );
+			$vouch = urldecode( $vouch );
 			// Safely store a version of the data
 			$comment_meta['webmention_vouch_url'] = esc_url_raw( $vouch );
 		}


### PR DESCRIPTION
This would result in a couple PHP warnings and cause the `webmention_vouch_url` to always store as an empty string, even if a vouch URL was provided.

```bash
wp> $vouch = urldecode( $params['vouch'] );
=> string(0) ""
wp> esc_url_raw( $vouch );
=> string(0) ""
```