### PR TITLE
Check version when settings page is loaded

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -230,6 +230,10 @@ class Admin {
 	 * Load settings page
 	 */
 	public static function settings_page() {
+		require_once dirname( __FILE__ ) . '/class-db.php';
+		\Webmention\DB::update_database();
+		\Webmention\remove_semantic_linkbacks();
+
 		add_thickbox();
 		wp_enqueue_script( 'plugin-install' );
 		load_template( dirname( __FILE__ ) . '/../templates/webmention-settings.php' );


### PR DESCRIPTION
This is the simplest way of ensuring migration is checked after activation. It runs the upgrade check each time you visit the settings page, so that avoids checking it on every page load, in the event it doesn't trigger on upgrade.

I thought about more complicated options, but this covers us in most cases.