### PR TITLE
Remove Gravatar Code

### DIFF
--- a/includes/class-avatar.php
+++ b/includes/class-avatar.php
@@ -14,21 +14,11 @@ class Avatar {
 	 */
 	public static function init() {
 		add_filter( 'pre_get_avatar_data', array( static::class, 'avatar_stored_in_comment' ), 30, 2 );
-		add_filter( 'get_avatar_data', array( static::class, 'anonymous_avatar_data' ), 30, 2 );
-
-		// All the default gravatars come from Gravatar instead of being generated locally so add a local default
-		add_filter( 'avatar_defaults', array( static::class, 'anonymous_avatar' ) );
 
 		// Allow for avatars on Webmention comment types
 		if ( 0 !== (int) get_option( 'webmention_avatars', 1 ) ) {
 			add_filter( 'get_avatar_comment_types', array( static::class, 'get_avatar_comment_types' ), 99 );
 		}
-	}
-
-	public static function anonymous_avatar( $avatar_defaults ) {
-		$avatar_defaults['mystery'] = __( 'Mystery Person (hosted locally)', 'webmention' );
-
-		return $avatar_defaults;
 	}
 
 	/**
@@ -58,103 +48,6 @@ class Avatar {
 		return $avatar;
 	}
 
-
-	/**
-	 * Function to retrieve default avatar URL
-	 *
-	 *
-	 * @param string $type Default Avatar URL
-	 *
-	 * @return string|boolean $url
-	 */
-	public static function get_default_avatar( $type = null ) {
-		if ( ! $type ) {
-			$type = get_option( 'avatar_default', 'mystery' );
-		}
-
-		switch ( $type ) {
-			case 'mm':
-			case 'mystery':
-			case 'mysteryman':
-				return plugin_dir_url( dirname( __FILE__ ) ) . 'assets/img/mm.jpg';
-		}
-
-		return apply_filters( 'webmention_default_avatar', $type );
-	}
-
-	/**
-	 * Function to check if there is a gravatar
-	 *
-	 *
-	 * @param WP_Comment $comment
-	 *
-	 * @return boolean
-	 */
-	public static function check_gravatar( $comment, $args = null ) {
-		if ( ! empty( $comment->comment_author_email ) ) {
-			$hash = md5( strtolower( trim( $comment->comment_author_email ) ) );
-		} elseif ( is_array( $args ) && array_key_exists( 'url', $args ) ) {
-			if ( ! strpos( $args['url'], 'gravatar.com' ) ) {
-				return false;
-			}
-			$hash = wp_parse_url( $args['url'], PHP_URL_PATH );
-			$hash = str_replace( '/avatar/', '', $hash );
-		} else {
-			return false;
-		}
-
-		$found = get_transient( 'webmention_gravatar_' . $hash );
-
-		if ( false !== $found ) {
-			return $found;
-		} else {
-			$url      = 'https://www.gravatar.com/avatar/' . $hash . '?d=404';
-			$response = wp_remote_head( $url );
-			$found    = ( is_wp_error( $response ) || 404 === wp_remote_retrieve_response_code( $response ) ) ? 0 : 1;
-			set_transient( 'webmention_gravatar_' . $hash, $found, WEBMENTION_GRAVATAR_CACHE_TIME );
-		}
-
-		return $found;
-	}
-
-	/**
-	 * Replaces the default avatar with a locally stored default
-	 *
-	 * @param array      $args    Arguments passed to get_avatar_data(), after processing.
-	 * @param WP_Comment $comment A comment object
-	 *
-	 * @return array $args
-	 */
-	public static function anonymous_avatar_data( $args, $comment ) {
-		if ( ! $comment instanceof WP_Comment ) {
-			return $args;
-		}
-
-		$local = apply_filters( 'webmention_local_avatars', array( 'mm', 'mystery', 'mysteryman' ) );
-
-		if ( ! in_array( $args['default'], $local, true ) ) {
-			return $args;
-		}
-
-		// Always override if default forced
-		if ( $args['force_default'] ) {
-			$args['url'] = self::get_default_avatar( $args['default'] );
-			return $args;
-		}
-
-		if ( ! strpos( $args['url'], 'gravatar.com' ) ) {
-			return $args;
-		}
-
-		if ( self::check_gravatar( $comment, $args ) ) {
-			return $args;
-		}
-
-		$args['url'] = self::get_default_avatar();
-
-		return $args;
-	}
-
 	/**
 	 * If there is an avatar stored in comment meta use it
 	 *
@@ -170,7 +63,7 @@ class Avatar {
 		}
 
 		// Simple method to prevent broken images
-		$args['extra_attr'] .= sprintf( ' onerror="this.onerror=null;this.src=\'%1$s\';this.srcset=\'%1$s\';"', self::get_default_avatar() );
+		$args['extra_attr'] .= sprintf( ' onerror="this.onerror=null;this.src=\'%1$s\';this.srcset=\'%1$s\';"', plugin_dir_url( dirname( __FILE__ ) ) . 'assets/img/mm.jpg' );
 
 		// If another filter has already provided a url
 		if ( isset( $args['url'] ) && wp_http_validate_url( $args['url'] ) ) {
@@ -200,6 +93,7 @@ class Avatar {
 				$args['class'][] = 'local-avatar';
 				$args['class']   = array_unique( $args['class'] );
 			}
+			$args['found_avatar'] = true;
 		}
 
 		return $args;

--- a/readme.txt
+++ b/readme.txt
@@ -75,11 +75,8 @@ As Webmention uses the REST API endpoint system, most up to date caching plugins
 
 = Why does this plugin have settings about avatars? =
 
-Webmentions have the ability to act as rich comments. This includes showing avatars. If there is an avatar discovered, the URL for it will be stored. This can either be reflect something from the media library or a URL of a file.
-
-Since Webmentions do not usually have email addresses, Gravatar, built into WordPress, is not necessary. WordPress returns even the anonymous avatars from Gravatar. Therefore, if there is no email the plugin will simply return a local copy of the Mystery Man default avatar. If there is an email address, the plugin will cache whether a Gravatar exists and serve the local file if it does not. It defaults to a week, but you can change it to a day, or any number by adding below to your wp-config.php file.
-
-    define( 'WEBMENTION_GRAVATAR_CACHE_TIME', DAY_IN_SECONDS );
+Webmentions have the ability to act as rich comments. This includes showing avatars. If there is an avatar discovered, the URL for it will be stored. This can either be reflect something from the media library or a URL of a file. If the file is broken, it will store a local
+copy of the default gravatar image.
 
 = There are no Webmention headers on some pages of my site =
 


### PR DESCRIPTION
Being as it seems the thought is that we'd be better served by having avatar storage and caching handled by a separate plugin, this removes gravatar caching code, which is unnecessary as it only worked if the webmention had an author email, which is statistically unlikely.

