### PR TITLE
Update dupe check

### DIFF
--- a/includes/class-receiver.php
+++ b/includes/class-receiver.php
@@ -528,40 +528,40 @@ class Receiver {
 		$fragment = wp_parse_url( $commentdata['target'], PHP_URL_FRAGMENT );
 		// Meta Query for searching for the URL
 		$meta_query = array(
-					'relation' => 'OR',
-					// This would catch incoming webmentions with the same source URL
-					array(
-						'key'     => 'webmention_source_url',
-						'value'   => $commentdata['comment_meta']['webmention_source_url'],
-						'compare' => '=',
-					),
+			'relation' => 'OR',
+			// This would catch incoming webmentions with the same source URL
+			array(
+				'key'     => 'webmention_source_url',
+				'value'   => $commentdata['comment_meta']['webmention_source_url'],
+				'compare' => '=',
+			),
 
-					// This should catch incoming webmentions with the same canonical URL for Bridgy
-					array(
-						'key'     => 'url',
-						'value'   => $commentdata['comment_meta']['webmention_source_url'],
-						'compare' => '=',
-					),
-					// check comments sent via salmon are also dupes
-					// or anyone else who can't use comment_author_url as the original link,
-					// but can use a _crossposting_link meta value.
-					// @link https://github.com/pfefferle/wordpress-salmon
-					array(
-						'key'     => '_crossposting_link',
-						'value'   => $commentdata['comment_meta']['webmention_source_url'],
-						'compare' => '=',
-					),
+			// This should catch incoming webmentions with the same canonical URL for Bridgy
+			array(
+				'key'     => 'url',
+				'value'   => $commentdata['comment_meta']['webmention_source_url'],
+				'compare' => '=',
+			),
+			// check comments sent via salmon are also dupes
+			// or anyone else who can't use comment_author_url as the original link,
+			// but can use a _crossposting_link meta value.
+			// @link https://github.com/pfefferle/wordpress-salmon
+			array(
+				'key'     => '_crossposting_link',
+				'value'   => $commentdata['comment_meta']['webmention_source_url'],
+				'compare' => '=',
+			),
 
-					// This would catch incoming activitypub matches, which uses source_url
-					array(
-						'key'     => 'source_url',
-						'value'   => $commentdata['comment_meta']['webmention_source_url'],
-						'compare' => '=',
-					),
-				);
-		$args     = array(
+			// This would catch incoming activitypub matches, which uses source_url
+			array(
+				'key'     => 'source_url',
+				'value'   => $commentdata['comment_meta']['webmention_source_url'],
+				'compare' => '=',
+			),
+		);
+		$args = array(
 			'post_id'    => $commentdata['comment_post_ID'],
-			'meta_query' => array( $meta_query )
+			'meta_query' => array( $meta_query ),
 		);
 
 		if ( ! empty( $fragment ) ) {

--- a/includes/class-receiver.php
+++ b/includes/class-receiver.php
@@ -520,6 +520,11 @@ class Receiver {
 			return $commentdata;
 		}
 
+		// This check should never be tripped as all current webmentions should have the source url property.
+		if ( ! array_key_exists( 'comment_meta', $commentdata ) && ! array_key_exists( 'webmention_source_url', $commentdata['comment_meta'] ) ) {
+			return $commentdata;
+		}
+
 		$fragment = wp_parse_url( $commentdata['target'], PHP_URL_FRAGMENT );
 		$args     = array(
 			'post_id'    => $commentdata['comment_post_ID'],

--- a/includes/class-receiver.php
+++ b/includes/class-receiver.php
@@ -501,10 +501,7 @@ class Receiver {
 			return $dupe_id;
 		}
 
-		if (
-			( isset( $commentdata['comment_type'] ) && 'webmention' === $commentdata['comment_type'] ) ||
-			( isset( $commentdata['comment_meta'] ) && ! empty( $commentdata['comment_meta']['semantic_linkbacks_type'] ) )
-		) {
+		if ( ! empty( $commentdata['comment_meta']['protocol'] ) && 'webmention' === $commentdata['comment_meta']['protocol'] ) {
 			return 0;
 		}
 
@@ -524,76 +521,61 @@ class Receiver {
 		}
 
 		$fragment = wp_parse_url( $commentdata['target'], PHP_URL_FRAGMENT );
-		if ( ! empty( $fragment ) ) {
-			// Check for the newer meta value before checking for the more traditional location
-			$args = array(
-				'post_id'    => $commentdata['comment_post_ID'],
-				'meta_query' => array(
+		$args     = array(
+			'post_id'    => $commentdata['comment_post_ID'],
+			'meta_query' => array(
+				array(
+					'relation' => 'OR',
+					// This would catch incoming webmentions with the same source URL
 					array(
 						'key'     => 'webmention_source_url',
-						'value'   => $commentdata['comment_author_url'],
+						'value'   => $commentdata['comment_meta']['webmention_source_url'],
 						'compare' => '=',
 					),
+
+					// This should catch incoming webmentions with the same canonical URL for Bridgy
 					array(
-						'key'     => 'webmention_target_fragment',
-						'value'   => $fragment,
+						'key'     => 'url',
+						'value'   => $commentdata['comment_meta']['webmention_source_url'],
+						'compare' => '=',
+					),
+					// check comments sent via salmon are also dupes
+					// or anyone else who can't use comment_author_url as the original link,
+					// but can use a _crossposting_link meta value.
+					// @link https://github.com/pfefferle/wordpress-salmon
+					array(
+						'key'     => '_crossposting_link',
+						'value'   => $commentdata['comment_meta']['webmention_source_url'],
+						'compare' => '=',
+					),
+
+					// This would catch incoming activitypub matches, which uses source_url
+					array(
+						'key'     => 'source_url',
+						'value'   => $commentdata['comment_meta']['webmention_source_url'],
 						'compare' => '=',
 					),
 				),
-			);
-		} else {
-			$args = array(
-				'post_id'    => $commentdata['comment_post_ID'],
-				'meta_key'   => 'webmention_source_url',
-				'meta_value' => $commentdata['comment_author_url'],
-			);
-		}
-
-		$comments = get_comments( $args );
-		// check result
-		if ( ! empty( $comments ) ) {
-			$comment                         = $comments[0];
-			$commentdata['comment_ID']       = $comment->comment_ID;
-			$commentdata['comment_approved'] = $comment->comment_approved;
-
-			return $commentdata;
-		}
-
-		// Check in comment_author_url if the newer location is empty
-		$args = array(
-			'post_id'    => $commentdata['comment_post_ID'],
-			'author_url' => $commentdata['comment_author_url'],
+			),
 		);
-		// If there is a fragment in the target URL then use this in the dupe search
+
 		if ( ! empty( $fragment ) ) {
-			$args['meta_key']   = 'webmention_target_fragment';
-			$args['meta_value'] = $fragment;
+			// Ensure that if there is a
+			$args['meta_query'][0][] = array(
+				'key'     => 'webmention_target_fragment',
+				'value'   => $fragment,
+				'compare' => '=',
+			);
 		}
+
 		$comments = get_comments( $args );
 		// check result
 		if ( ! empty( $comments ) ) {
 			$comment                         = $comments[0];
 			$commentdata['comment_ID']       = $comment->comment_ID;
 			$commentdata['comment_approved'] = $comment->comment_approved;
+
 			return $commentdata;
-		}
-
-		// check comments sent via salmon are also dupes
-		// or anyone else who can't use comment_author_url as the original link,
-		// but can use a _crossposting_link meta value.
-		// @link https://github.com/pfefferle/wordpress-salmon/blob/master/plugin.php#L192
-		$args     = array(
-			'post_id'    => $commentdata['comment_post_ID'],
-			'meta_key'   => '_crossposting_link',
-			'meta_value' => $commentdata['comment_author_url'],
-		);
-		$comments = get_comments( $args );
-
-		// check result
-		if ( ! empty( $comments ) ) {
-			$comment                         = $comments[0];
-			$commentdata['comment_ID']       = $comment->comment_ID;
-			$commentdata['comment_approved'] = $comment->comment_approved;
 		}
 
 		return $commentdata;

--- a/includes/class-receiver.php
+++ b/includes/class-receiver.php
@@ -526,10 +526,8 @@ class Receiver {
 		}
 
 		$fragment = wp_parse_url( $commentdata['target'], PHP_URL_FRAGMENT );
-		$args     = array(
-			'post_id'    => $commentdata['comment_post_ID'],
-			'meta_query' => array(
-				array(
+		// Meta Query for searching for the URL
+		$meta_query = array(
 					'relation' => 'OR',
 					// This would catch incoming webmentions with the same source URL
 					array(
@@ -560,13 +558,15 @@ class Receiver {
 						'value'   => $commentdata['comment_meta']['webmention_source_url'],
 						'compare' => '=',
 					),
-				),
-			),
+				);
+		$args     = array(
+			'post_id'    => $commentdata['comment_post_ID'],
+			'meta_query' => array( $meta_query )
 		);
 
 		if ( ! empty( $fragment ) ) {
-			// Ensure that if there is a
-			$args['meta_query'][0][] = array(
+			// Ensure that if there is a fragment it is matched
+			$args['meta_query'][] = array(
 				'key'     => 'webmention_target_fragment',
 				'value'   => $fragment,
 				'compare' => '=',


### PR DESCRIPTION
This updates the dupe check parameters to search for dupes by matching on webmention_source_url, url, _crossposting_link or source_url in one query instead of multiple queries. 

webmention_source url = the original source url
url = the canonical url in the event of something like a Bridgy post
_crossposting_link for Salmon
source_url for ActivityPub

