### PR TITLE
Add mf2 author migration

### DIFF
--- a/includes/class-db.php
+++ b/includes/class-db.php
@@ -41,8 +41,10 @@ class DB {
 
 		$version_from_db = self::get_version();
 
-		if ( version_compare( $version_from_db, '1.0.1', '<' ) ) {
+		if ( version_compare( $version_from_db, '1.0.0', '<' ) ) {
 			self::migrate_to_1_0_0();
+		}
+		if ( version_compare( $version_from_db, '1.0.1', '<' ) ) {
 			self::mf2_author_migration();
 		}
 
@@ -141,13 +143,13 @@ class DB {
 		);
 		foreach ( $comments as $comment_id ) {
 			$author = get_comment_meta( $comment_id, 'mf2_author', true );
+			$source = get_comment_meta( $comment_id, 'webmention_source_url', true );
 			if ( is_array( $author ) ) {
-				if ( array_key_exists( 'url', $author ) ) {
+				if ( array_key_exists( 'url', $author ) && ( $source !== $author['url'] ) ) {
 					$comment               = get_comment( $comment_id, ARRAY_A );
 					$comment['author_url'] = $author['url'];
 					wp_update_comment( $comment );
 				}
-				delete_comment_meta( $comment_id, 'mf2_author' );
 			}
 		}
 	}

--- a/includes/class-db.php
+++ b/includes/class-db.php
@@ -45,7 +45,7 @@ class DB {
 			self::migrate_to_1_0_0();
 		}
 		if ( version_compare( $version_from_db, '1.0.1', '<' ) ) {
-			self::mf2_author_migration();
+			self::migrate_to_1_0_1();
 		}
 
 		update_option( 'webmention_db_version', self::$target_version );
@@ -119,13 +119,13 @@ class DB {
 	}
 
 	/**
-	 * Author Migration tool from mf2_author
+	 * Migrate to version 1.0.1
 	 *
-	 * @since 5.0.0
+	 * @since 5.1.0
 	 *
 	 * @return void
 	 */
-	public static function mf2_author_migration() {
+	public static function migrate_to_1_0_1() {
 		$comments = get_comments(
 			array(
 				'fields'     => 'ids',

--- a/tests/test-db.php
+++ b/tests/test-db.php
@@ -23,7 +23,7 @@ class DB_Test extends WP_UnitTestCase {
 
 		\Webmention\DB::update_database();
 
-		$this->assertEquals( \Webmention\DB::get_version(), '1.0.0' );
+		$this->assertEquals( \Webmention\DB::get_version(), '1.0.1' );
 
 		wp_cache_flush();
 


### PR DESCRIPTION
This bumps the schema to 1.0.1 in order to run a function to extract the author url from mf2_author and update author_url.