### PR TITLE
Include spam and trash statuses for dupe check

### DIFF
--- a/includes/class-receiver.php
+++ b/includes/class-receiver.php
@@ -567,6 +567,7 @@ class Receiver {
 		$args = array(
 			'post_id'    => $commentdata['comment_post_ID'],
 			'meta_query' => array( $meta_query ),
+			'status' => 'any'
 		);
 
 		if ( ! empty( $fragment ) ) {

--- a/includes/class-receiver.php
+++ b/includes/class-receiver.php
@@ -567,7 +567,7 @@ class Receiver {
 		$args = array(
 			'post_id'    => $commentdata['comment_post_ID'],
 			'meta_query' => array( $meta_query ),
-			'status' => 'any'
+			'status' => 'any',
 		);
 
 		if ( ! empty( $fragment ) ) {


### PR DESCRIPTION
Resolves #341

The code shows 'any' as an option, but the documentation doesn't. Filed a ticket. If I read WP_Comment_query correctly, all actually doesn't include spam and trash, but any does.