### PR TITLE
Remove unnecessary loading of `comments.php`

### DIFF
--- a/templates/webmention-comments.php
+++ b/templates/webmention-comments.php
@@ -33,6 +33,3 @@ foreach ( $grouped_mentions as $mention_type => $mentions ) {
 }
 
 do_action( 'webmention_after_reaction_list' );
-
-load_template( locate_template( 'comments.php' ) );
-?>


### PR DESCRIPTION
As mentioned in #404, I'm 95% sure `comments.php` should no longer be loaded at the end of the `comment_form_before` callback, precisely because the hook is called _from_ (a function inside) `comments.php`.

On "classic" sites, this somehow works (i.e., there is no noticeable problem), but on sites running a block theme, this leads to both a deprecation notice (expected behavior) and the comment form being shown twice.

(It might also run OK on "block theme sites" that utilize the so-called legacy comments block. Either way, I think it's safe to remove the call. I tested in combination with a number of block and classic themes from various vendors.)