### PR TITLE
Switch from set to add to avoid meta overriding mf2

### DIFF
--- a/includes/Handler/class-meta.php
+++ b/includes/Handler/class-meta.php
@@ -96,7 +96,7 @@ class Meta extends Base {
 		foreach ( $mapping as $key => $values ) {
 			foreach ( $values as $value ) {
 				if ( array_key_exists( $value, $meta ) ) {
-					$this->webmention_item->set( $key, $meta[ $value ] );
+					$this->webmention_item->add( $key, $meta[ $value ] );
 					break;
 				}
 			}


### PR DESCRIPTION
This is based on the webmention sent from https://minutestomidnight.co.uk/notes/2023-07-13-10-52-06/ to 
https://tracydurnell.com/2023/07/12/barriers-to-a-more-social-indieweb/ where the content is actually wrong and coming from meta when a better microformats options is there.