### PR TITLE
Use summary when appropriate

### DIFF
--- a/includes/Entity/class-item.php
+++ b/includes/Entity/class-item.php
@@ -285,9 +285,9 @@ class Item {
 		$text_len = $this->str_length( $this->content );
 
 		if ( ( 0 === $text_len ) ) {
-			if ( ! empty( $this->summary ) ) {
+			if ( $this->summary ) {
 				return $this->summary;
-			} elseif ( ! empty( $this->name ) ) {
+			} elseif ( $this->name ) {
 				return $this->name;
 			}
 		}
@@ -298,9 +298,9 @@ class Item {
 		}
 
 		// If there is a summary that isn't empty, return that, if not the name.
-		if ( ! empty( $this->summary ) ) {
+		if ( $this->summary ) {
 			return $this->summary;
-		} elseif ( ! empty( $this->name ) ) {
+		} elseif ( $this->name ) {
 			return $this->name;
 		}
 

--- a/includes/Entity/class-item.php
+++ b/includes/Entity/class-item.php
@@ -282,15 +282,29 @@ class Item {
 	 * @return string
 	 */
 	public function get_content() {
-		if ( $this->content ) {
-			return $this->content;
-		} elseif ( $this->summary ) {
-			return $this->summary;
-		} elseif ( $this->name ) {
-			return $this->name;
-		} else {
-			return '';
+		$text_len = $this->str_length( $this->content );
+
+		if ( ( 0 === $text_len ) ) {
+			if ( ! empty( $this->summary ) ) {
+				return $this->summary;
+			} elseif ( ! empty( $this->name ) ) {
+				return $this->name;
+			} 
 		}
+
+		// If this is set to a comment type or if if the content if less than maximum, always return.
+		if ( 'comment' === $this->response_type || $text_len <= MAX_INLINE_MENTION_LENGTH ) {
+			return $this->content;
+		}
+
+		// If there is a summary that isn't empty, return that, if not the name.
+		if ( ! empty( $this->summary ) ) {
+			return $this->summary;
+		} elseif ( ! empty( $this->name ) ) {
+			return $this-name;
+		}	
+
+		return '';
 	}
 
 	/**
@@ -303,15 +317,25 @@ class Item {
 		// Reclassify short mentions as comments
 		if ( 'mention' === $response_type ) {
 			$text = $this->get_content();
-			if ( is_string( $text ) ) {
-				$text_len = mb_strlen( wp_strip_all_tags( html_entity_decode( $text, ENT_QUOTES ) ) );
-				if ( $text_len <= MAX_INLINE_MENTION_LENGTH ) {
-					return 'comment';
-				}
+			$text_len = $this->str_length( $text );
+			if ( ( 0 < $text_len ) && ( $text_len <= MAX_INLINE_MENTION_LENGTH ) ) {
+				return 'comment';
 			}
 		}
 		return $response_type;
 	}
+
+	/**
+	 * String length function
+	 * @return int
+	 */
+	 public function str_length( $text ) {
+		if ( ! is_string( $text ) ) {
+			return 0;
+		}
+		return mb_strlen( wp_strip_all_tags( html_entity_decode( $text, ENT_QUOTES ) ) );
+	 }
+	 
 
 	/**
 	 * Getter for "published".

--- a/includes/Entity/class-item.php
+++ b/includes/Entity/class-item.php
@@ -289,7 +289,7 @@ class Item {
 				return $this->summary;
 			} elseif ( ! empty( $this->name ) ) {
 				return $this->name;
-			} 
+			}
 		}
 
 		// If this is set to a comment type or if if the content if less than maximum, always return.
@@ -301,8 +301,8 @@ class Item {
 		if ( ! empty( $this->summary ) ) {
 			return $this->summary;
 		} elseif ( ! empty( $this->name ) ) {
-			return $this-name;
-		}	
+			return $this - name;
+		}
 
 		return '';
 	}
@@ -316,7 +316,7 @@ class Item {
 		$response_type = $this->response_type ? $this->response_type : 'mention';
 		// Reclassify short mentions as comments
 		if ( 'mention' === $response_type ) {
-			$text = $this->get_content();
+			$text     = $this->get_content();
 			$text_len = $this->str_length( $text );
 			if ( ( 0 < $text_len ) && ( $text_len <= MAX_INLINE_MENTION_LENGTH ) ) {
 				return 'comment';
@@ -329,13 +329,13 @@ class Item {
 	 * String length function
 	 * @return int
 	 */
-	 public function str_length( $text ) {
+	public function str_length( $text ) {
 		if ( ! is_string( $text ) ) {
 			return 0;
 		}
 		return mb_strlen( wp_strip_all_tags( html_entity_decode( $text, ENT_QUOTES ) ) );
-	 }
-	 
+	}
+
 
 	/**
 	 * Getter for "published".

--- a/includes/Entity/class-item.php
+++ b/includes/Entity/class-item.php
@@ -301,7 +301,7 @@ class Item {
 		if ( ! empty( $this->summary ) ) {
 			return $this->summary;
 		} elseif ( ! empty( $this->name ) ) {
-			return $this - name;
+			return $this->name;
 		}
 
 		return '';


### PR DESCRIPTION
If the response type is expressly set to comment, then this will always return the full content. Otherwise, it will return the content if it is short enough, if not the summary, if not the name, if not nothing.

I debated on the nothing vs a generated excerpt. But if we were to do a generated excerpt, I'd want to discuss how we'd excerpt as a topic. For example, number of characters = MAX_INLINE_MENTION_LENGTH? Try to mirror Pingbacks and get the context around the link to the target? Etc.