### PR TITLE
Performance: only enqueue CSS on pages with a comment form

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,10 @@ While not all display options can be settings, we are looking to provide some si
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
 
+### Next ###
+
+* Fixed: avoid enqueuing Webmention's CSS stylesheet when it is not needed.
+
 ### 5.1.3 ###
 
 * Fix timezone issue causes exception

--- a/readme.txt
+++ b/readme.txt
@@ -99,6 +99,10 @@ While not all display options can be settings, we are looking to provide some si
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
 
+= Next =
+
+* Fixed: avoid enqueuing Webmention's CSS stylesheet when it is not needed.
+
 = 5.1.3 =
 
 * Fix timezone issue causes exception

--- a/webmention.php
+++ b/webmention.php
@@ -154,7 +154,9 @@ register_activation_hook( __FILE__, '\Webmention\activation' );
  * Add CSS and JavaScript
  */
 function enqueue_scripts() {
-	wp_enqueue_style( 'webmention', plugin_dir_url( __FILE__ ) . 'assets/css/webmention.css', array(), version() );
+	if ( \is_singular() && \comments_open() ) {
+		wp_enqueue_style( 'webmention', plugin_dir_url( __FILE__ ) . 'assets/css/webmention.css', array(), version() );
+	}
 }
 
 /**


### PR DESCRIPTION
Instead of enqueuing the Webmention CSS on all pages of the site, we could try only enqueuing it on singular pages (posts / pages / CPTs) where comments are open.