### PR TITLE
Introduce HTML link search and add it to wp as a fallback

### DIFF
--- a/includes/Handler/class-wp.php
+++ b/includes/Handler/class-wp.php
@@ -49,7 +49,6 @@ class WP extends Base {
 			);
 		}
 
-
 		if ( ! $root_api_links || ! is_array( $root_api_links ) ) {
 			return new WP_Error( 'no_api_link', __( 'No API link found in the source code', 'webmention' ) );
 		}

--- a/includes/Handler/class-wp.php
+++ b/includes/Handler/class-wp.php
@@ -40,6 +40,17 @@ class WP extends Base {
 		);
 
 		if ( ! $root_api_links || ! is_array( $root_api_links ) ) {
+			$root_api_links = $response->get_html_links_by( array( 'rel' => 'https://api.w.org/' ) );
+			$post_api_links = $response->get_html_links_by(
+				array(
+					'rel'  => 'alternate',
+					'type' => 'application/json',
+				)
+			);
+		}
+
+
+		if ( ! $root_api_links || ! is_array( $root_api_links ) ) {
 			return new WP_Error( 'no_api_link', __( 'No API link found in the source code', 'webmention' ) );
 		}
 

--- a/includes/class-response.php
+++ b/includes/class-response.php
@@ -4,6 +4,7 @@ namespace Webmention;
 
 use WP_Error;
 use DOMDocument;
+use DOMXPath;
 
 /**
  * Encapsulates all Webmention HTTP requests
@@ -232,6 +233,27 @@ class Response {
 	}
 
 	/**
+	 * Parses HTML links
+	 *
+	 * @return array
+	 */
+	public function get_html_links() {
+		$dom = $this->get_dom_document();
+		$xpath = new DOMXPath( $dom );
+		$items = array();
+
+		// check <link> and <a> elements
+		foreach ( $xpath->query( '(//link|//a)[@rel and @href]' ) as $link ) {
+			$item = array();
+			$item['rel']   = $link->getAttribute( 'rel' );
+			$item['uri']  = $link->getAttribute( 'href' );
+			$item['type'] = $link->getAttribute( 'type' );
+			$items[] = $item;
+		}
+		return $items;
+	}
+
+	/**
 	 * Get link headers by a filter
 	 *
 	 * @param array $filter Filter link headers
@@ -252,6 +274,31 @@ class Response {
 
 		return $items;
 	}
+
+
+	/**
+	 * Get html link headers by a filter
+	 *
+	 * @param array $filter Filter link headers
+	 *
+	 * @example array( 'rel' => 'alternate', 'type' => 'application/json' )
+	 *
+	 * @return array
+	 */
+	public function get_html_links_by( $filter ) {
+		$links = $this->get_html_links();
+		$items = array();
+
+		foreach ( $links as $link ) {
+			if ( array_intersect_uassoc( $link, $filter, 'strcasecmp' ) ) {
+				$items[] = $link;
+			}
+		}
+
+		return $items;
+	}
+
+
 
 	/**
 	 * Check if request returns an HTTP Error Code

--- a/includes/class-response.php
+++ b/includes/class-response.php
@@ -238,17 +238,17 @@ class Response {
 	 * @return array
 	 */
 	public function get_html_links() {
-		$dom = $this->get_dom_document();
+		$dom   = $this->get_dom_document();
 		$xpath = new DOMXPath( $dom );
 		$items = array();
 
 		// check <link> and <a> elements
 		foreach ( $xpath->query( '(//link|//a)[@rel and @href]' ) as $link ) {
-			$item = array();
-			$item['rel']   = $link->getAttribute( 'rel' );
+			$item         = array();
+			$item['rel']  = $link->getAttribute( 'rel' );
 			$item['uri']  = $link->getAttribute( 'href' );
 			$item['type'] = $link->getAttribute( 'type' );
-			$items[] = $item;
+			$items[]      = $item;
 		}
 		return $items;
 	}


### PR DESCRIPTION
This adds functions to retrieve HTML links in the response class and then uses it in the wp search if it can't find an API link in the header.