### PR TITLE
simplify html/head link discovery

### DIFF
--- a/includes/Handler/class-wp.php
+++ b/includes/Handler/class-wp.php
@@ -31,10 +31,15 @@ class WP extends Base {
 	 * @return WP_Error|true Return error or true if successful.
 	 */
 	public function parse( Response $response, $target_url ) {
-		$site_api_links = $this->get_site_api_links( $response );
-		$post_api_links = $this->get_post_api_links( $response );
+		$site_api_links = $response->get_links_by( array( 'rel' => 'https://api.w.org/' ) );
+		$post_api_links = $response->get_links_by(
+			array(
+				'rel'  => 'alternate',
+				'type' => 'application/json',
+			)
+		);
 
-		if ( is_wp_error( $site_api_links ) || is_wp_error( $post_api_links ) ) {
+		if ( ! $site_api_links || ! $post_api_links ) {
 			return new WP_Error( 'no_api_link', __( 'No API link found in the source code', 'webmention' ) );
 		}
 
@@ -95,21 +100,12 @@ class WP extends Base {
 	 * @return string|WP_Error The API link or WP_Error if none found.
 	 */
 	public function get_post_api_links( Response $response ) {
-		$post_api_links = $response->get_header_links_by(
+		$post_api_links = $response->get_links_by(
 			array(
 				'rel'  => 'alternate',
 				'type' => 'application/json',
 			)
 		);
-
-		if ( ! $post_api_links || ! is_array( $post_api_links ) ) {
-			$post_api_links = $response->get_html_links_by(
-				array(
-					'rel'  => 'alternate',
-					'type' => 'application/json',
-				)
-			);
-		}
 
 		if ( ! $post_api_links || ! is_array( $post_api_links ) ) {
 			return new WP_Error( 'no_api_link', __( 'No API link found in the source code', 'webmention' ) );

--- a/includes/class-discovery.php
+++ b/includes/class-discovery.php
@@ -173,24 +173,10 @@ class Discovery {
 			return false;
 		}
 
-		$links = $response->get_header_links_by( array( 'rel' => 'webmention' ) );
+		$links = $response->get_links_by( array( 'rel' => 'webmention' ) );
 
 		if ( $links ) {
 			return WP_Http::make_absolute_url( $links[0]['uri'], $url );
-		}
-
-		$dom = $response->get_dom_document();
-
-		if ( is_wp_error( $dom ) ) {
-			return false;
-		}
-
-		$xpath = new DOMXPath( $dom );
-
-		// check <link> and <a> elements
-		// checks only body>a-links
-		foreach ( $xpath->query( '(//link|//a)[contains(concat(" ", @rel, " "), " webmention ") or contains(@rel, "webmention.org")]/@href' ) as $result ) {
-			return WP_Http::make_absolute_url( $result->value, $url );
 		}
 
 		return false;

--- a/includes/class-response.php
+++ b/includes/class-response.php
@@ -247,9 +247,9 @@ class Response {
 			$rels = explode( ' ', $link->getAttribute( 'rel' ) );
 			foreach ( $rels as $rel ) {
 				$item         = array();
-				$item['rel']  = $rel;
-				$item['uri']  = $link->getAttribute( 'href' );
-				$item['type'] = $link->getAttribute( 'type' );
+				$item['rel']  = trim( $rel );
+				$item['uri']  = trim( $link->getAttribute( 'href' ) );
+				$item['type'] = trim( $link->getAttribute( 'type' ) );
 				$items[]      = $item;
 			}
 		}

--- a/tests/test-discovery.php
+++ b/tests/test-discovery.php
@@ -147,6 +147,7 @@ class Discovery_Test extends WP_UnitTestCase {
 
 		add_filter( 'pre_http_request', array( $this, 'discover_multiple_htmllink' ) );
 		$endpoint = webmention_discover_endpoint( $url );
+
 		$this->assertSame( 'http://www.example.com/test/9/webmention', $endpoint );
 	}
 

--- a/tests/test-handler-wp.php
+++ b/tests/test-handler-wp.php
@@ -10,12 +10,16 @@ class WP_Handler_Meta_Test extends WP_UnitTestCase {
 		$response->set_content_type( 'text/html' );
 		$response->set_body( file_get_contents( dirname( __FILE__ ) . '/data/wp-api-discovery-test.html' ) );
 
-		$handler = new \Webmention\Handler\WP();
-		$site_api_links = $handler->get_site_api_links( $response );
+		$site_api_links = $response->get_links_by( array( 'rel' => 'https://api.w.org/' ) );
 
 		$this->assertEquals( 'https://notiz.blog/wp-api/', $site_api_links[0]['uri'] );
 
-		$post_api_links = $handler->get_post_api_links( $response );
+		$post_api_links = $response->get_links_by(
+			array(
+				'rel'  => 'alternate',
+				'type' => 'application/json',
+			)
+		);
 
 		$this->assertEquals( 'https://notiz.blog/wp-api/wp/v2/posts/5307', $post_api_links[0]['uri'] );
 	}


### PR DESCRIPTION
Simplify the discovery mechanism by introducing a `get_links_by` function in the Response Object, that checks HTML and HTTP-Header Links.