### PR TITLE
use source-link only on frontend and for Webmentions

### DIFF
--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -31,10 +31,14 @@ class Comment {
 	 * @return string $url The url of the source.
 	 */
 	public static function remote_comment_link( $comment_link, $comment ) {
-		$link = get_url_from_webmention( $comment );
+		if ( is_admin() || ! is_webmention( $comment ) ) {
+			return $comment_link;
+		}
 
-		if ( $link ) {
-			$comment_link = $link;
+		$webmention_link = get_url_from_webmention( $comment );
+
+		if ( $webmention_link ) {
+			return $webmention_link;
 		}
 
 		return $comment_link;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -340,7 +340,6 @@ function webmention_extract_urls( $content, $support_media_urls = false ) {
 	return array_filter( $urls );
 }
 
-
 /**
  * Returns whether this is a Webmention Comment Type
  *
@@ -653,4 +652,27 @@ function webmention_refresh( $comment ) {
 	} else {
 		return $response;
 	}
+}
+
+/**
+ * Return whether a comment is a Webmention.
+ *
+ * @param int|WP_Comment $comment Comment object or ID.
+ *
+ * @return boolean Return true if comment is a Webmention.
+ */
+function is_webmention( $comment ) {
+	$comment = get_comment( $comment );
+
+	if ( ! $comment ) {
+		return false;
+	}
+
+	$protocol = get_comment_meta( $comment->comment_ID, 'protocol', true );
+
+	if ( 'webmention' === $protocol ) {
+		return true;
+	}
+
+	return false;
 }


### PR DESCRIPTION
See: https://wordpress.org/support/topic/breaks-ordinary-comment-permalink-links/