### PR TITLE
Do not bypass spam detection

### DIFF
--- a/includes/class-receiver.php
+++ b/includes/class-receiver.php
@@ -684,7 +684,7 @@ class Receiver {
 			return 1;
 		}
 
-		return self::is_source_allowed( $commentdata['source'] ) ? 1 : 0;
+		return self::is_source_allowed( $commentdata['source'] ) ? 1 : $approved;
 	}
 
 	/**

--- a/languages/webmention.pot
+++ b/languages/webmention.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: Webmention 5.1.9\n"
+"Project-Id-Version: Webmention 5.1.10\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wordpress-webmention\n"
-"POT-Creation-Date: 2023-11-18 15:05:08+00:00\n"
+"POT-Creation-Date: 2023-12-22 13:20:41+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Tags:** webmention, pingback, trackback, linkback, indieweb, comment, response  
 **Requires at least:** 4.9  
 **Tested up to:** 6.4  
-**Stable tag:** 5.1.9  
+**Stable tag:** 5.1.10  
 **Requires PHP:** 5.6  
 **License:** MIT  
 **License URI:** https://opensource.org/licenses/MIT  
@@ -98,6 +98,10 @@ While not all display options can be settings, we are looking to provide some si
 ## Changelog ##
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+### 5.1.10 ###
+
+* Do not bypass the spam filters
 
 ### 5.1.9 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://notiz.blog/donate/
 Tags: webmention, pingback, trackback, linkback, indieweb, comment, response
 Requires at least: 4.9
 Tested up to: 6.4
-Stable tag: 5.1.9
+Stable tag: 5.1.10
 Requires PHP: 5.6
 License: MIT
 License URI: https://opensource.org/licenses/MIT
@@ -98,6 +98,10 @@ While not all display options can be settings, we are looking to provide some si
 == Changelog ==
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+= 5.1.10 =
+
+* Do not bypass the spam filters
 
 = 5.1.9 =
 

--- a/webmention.php
+++ b/webmention.php
@@ -5,7 +5,7 @@
  * Description: Webmention support for WordPress posts
  * Author: Matthias Pfefferle
  * Author URI: https://notiz.blog/
- * Version: 5.1.9
+ * Version: 5.1.10
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT
  * Text Domain: webmention


### PR DESCRIPTION
In the current code, we bypass spam detection completely, because every Webmentions is always only `1` or `0`.

That makes spam detection useless and with spammers keeping up with new technologies like Webmentions, we should not bother our users to check every Mention.

What do you think @dshanske 

/cc @kbrown9 and @cybeardjm