### PR TITLE
Support Source Update Notifications

### DIFF
--- a/includes/Handler/class-mf2.php
+++ b/includes/Handler/class-mf2.php
@@ -595,17 +595,17 @@ class MF2 extends Base {
 	protected function get_class_mapper() {
 		$class_mapper = array();
 
-		/* 
+		/*
 		 * These classes represent the source sending a webmention based on its display of a mention sent by the target.
 		 * This sets the type to update, indicating that the purpose of the webmention is to notify of an update to the original webmention.
 		 */
-		$class_mapper['comment'] = 'update';
-		$class_mapper['like']    = 'update';
-		$class_mapper['favorite']    = 'update';
-		$class_mapper['repost']    = 'update';
-		$class_mapper['bookmark']    = 'update';
-		$class_mapper['read']    = 'read';
-		$class_mapper['listen']    = 'listen';
+		$class_mapper['comment']  = 'update';
+		$class_mapper['like']     = 'update';
+		$class_mapper['favorite'] = 'update';
+		$class_mapper['repost']   = 'update';
+		$class_mapper['bookmark'] = 'update';
+		$class_mapper['read']     = 'read';
+		$class_mapper['listen']   = 'listen';
 		$class_mapper['watch']    = 'watch';
 
 		/*

--- a/includes/Handler/class-mf2.php
+++ b/includes/Handler/class-mf2.php
@@ -595,6 +595,19 @@ class MF2 extends Base {
 	protected function get_class_mapper() {
 		$class_mapper = array();
 
+		/* 
+		 * These classes represent the source sending a webmention based on its display of a mention sent by the target.
+		 * This sets the type to update, indicating that the purpose of the webmention is to notify of an update to the original webmention.
+		 */
+		$class_mapper['comment'] = 'update';
+		$class_mapper['like']    = 'update';
+		$class_mapper['favorite']    = 'update';
+		$class_mapper['repost']    = 'update';
+		$class_mapper['bookmark']    = 'update';
+		$class_mapper['read']    = 'read';
+		$class_mapper['listen']    = 'listen';
+		$class_mapper['watch']    = 'watch';
+
 		/*
 		 * rsvp
 		 * @link https://indieweb.org/rsvp
@@ -611,28 +624,24 @@ class MF2 extends Base {
 		 * repost
 		 * @link https://indieweb.org/repost
 		 */
-		$class_mapper['repost']    = 'repost';
 		$class_mapper['repost-of'] = 'repost';
 
 		/*
 		 * likes
 		 * @link https://indieweb.org/likes
 		 */
-		$class_mapper['like']    = 'like';
 		$class_mapper['like-of'] = 'like';
 
 		/*
 		 * favorite
 		 * @link https://indieweb.org/favorite
 		 */
-		$class_mapper['favorite']    = 'favorite';
 		$class_mapper['favorite-of'] = 'favorite';
 
 		/*
 		 * bookmark
 		 * @link https://indieweb.org/bookmark
 		 */
-		$class_mapper['bookmark']    = 'bookmark';
 		$class_mapper['bookmark-of'] = 'bookmark';
 
 		/*
@@ -647,21 +656,18 @@ class MF2 extends Base {
 		 * @link https://indieweb.org/read
 		 */
 		$class_mapper['read-of'] = 'read';
-		$class_mapper['read']    = 'read';
 
 		/*
 		 * listen
 		 * @link https://indieweb.org/listen
 		 */
 		$class_mapper['listen-of'] = 'listen';
-		$class_mapper['listen']    = 'listen';
 
 		/*
 		 * watch
 		 * @link https://indieweb.org/watch
 		 */
 		$class_mapper['watch-of'] = 'watch';
-		$class_mapper['watch']    = 'watch';
 
 		/*
 		 * follow

--- a/includes/Handler/class-mf2.php
+++ b/includes/Handler/class-mf2.php
@@ -597,16 +597,16 @@ class MF2 extends Base {
 
 		/*
 		 * These classes represent the source sending a webmention based on its display of a mention sent by the target.
-		 * This sets the type to update, indicating that the purpose of the webmention is to notify of an update to the original webmention.
+		 * This sets the type to target-update, indicating that the purpose of the webmention is to notify of an update to the original webmention.
 		 */
-		$class_mapper['comment']  = 'update';
-		$class_mapper['like']     = 'update';
-		$class_mapper['favorite'] = 'update';
-		$class_mapper['repost']   = 'update';
-		$class_mapper['bookmark'] = 'update';
-		$class_mapper['read']     = 'read';
-		$class_mapper['listen']   = 'listen';
-		$class_mapper['watch']    = 'watch';
+		$class_mapper['comment']  = 'target-update';
+		$class_mapper['like']     = 'target-update';
+		$class_mapper['favorite'] = 'target-update';
+		$class_mapper['repost']   = 'target-update';
+		$class_mapper['bookmark'] = 'target-update';
+		$class_mapper['read']     = 'target-update';
+		$class_mapper['listen']   = 'target-update';
+		$class_mapper['watch']    = 'target-update';
 
 		/*
 		 * rsvp

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -56,6 +56,16 @@ class Comment {
 	}
 
 	/**
+	 * Is this a registered comment type
+	 *
+	 * @param string $slug The name of the type
+	 * @return boolean True if registered.
+	 */
+	public static function is_registered_comment_type( $slug ) {
+		return in_array( $slug, $this->get_comment_type_names(), true );
+	}
+
+	/**
 	 * Return the registered custom comment types names plus Webmention for backcompat.
 	 *
 	 * @return array The registered custom comment type names

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -62,7 +62,7 @@ class Comment {
 	 * @return boolean True if registered.
 	 */
 	public static function is_registered_comment_type( $slug ) {
-		return in_array( $slug, $this->get_comment_type_names(), true );
+		return in_array( $slug, self::get_comment_type_names(), true );
 	}
 
 	/**

--- a/includes/class-receiver.php
+++ b/includes/class-receiver.php
@@ -348,13 +348,13 @@ class Receiver {
 		 * notifying the author of the post to allow for manual action, throwing the post into a review status, updating a link preview embedded in the post, etc.
 		 */
 
-		if ( 'update' === $commentdata['comment_type'] ) {
+		if ( 'target-update' === $commentdata['comment_type'] ) {
 			/**
 			 * Fires if the received webmention is not a response but just an update notification.
 			 *
 			 * @param array $commentdata
 			 */
-			do_action( 'webmention_post_updated_notification', $commentdata );
+			do_action( 'webmention_target_updated_notification', $commentdata );
 
 			// Still return that it was successful
 			$return = array(

--- a/includes/class-receiver.php
+++ b/includes/class-receiver.php
@@ -342,12 +342,12 @@ class Receiver {
 		}
 
 		/*
-		 * The update comment type is currently representing when the mf2 markup in a source indicates the source link is 
+		 * The update comment type is currently representing when the mf2 markup in a source indicates the source link is
 		 * actually a marked up response...so we treat the webmention as an update notification.
 		 * TODO: Something. Currently, below code adds a hook that allows for action but does nothing by default. Possible actions someone could code would be
 		 * notifying the author of the post to allow for manual action, throwing the post into a review status, updating a link preview embedded in the post, etc.
 		 */
-	
+
 		if ( 'update' === $commentdata['comment_type'] ) {
 			/**
 			 * Fires if the received webmention is not a response but just an update notification.
@@ -355,7 +355,7 @@ class Receiver {
 			 * @param array $commentdata
 			 */
 			do_action( 'webmention_post_updated_notification', $commentdata );
-			
+
 			// Still return that it was successful
 			$return = array(
 				'source'  => $commentdata['source'],

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -35,6 +35,19 @@ function register_webmention_comment_type( $comment_type, $args = array() ) {
 	return $comment_type_object;
 }
 
+
+
+/**
+ * Is this a registered comment type
+ *
+ * @param string $slug The name of the type
+ * @return boolean True if registered.
+ */
+function is_registered_webmention_comment_type( $slug ) {
+	return \Webmention\Comment::is_registered_comment_type( $slug );
+}
+
+
 /**
  * Return the registered custom comment types.
  *

--- a/tests/data/mf2/brid-gy.html
+++ b/tests/data/mf2/brid-gy.html
@@ -18,9 +18,9 @@
   </div>
 
   <div class="e-content">
-  <a href="http://twitter.com/muhh/status/423756080376995840">retweeted this.</a><a class="u-repost u-repost-of" href="http://twitter.com/pfefferle/status/423744359297585152" />
-<a class="u-repost u-repost-of" href="http://notizblog.org/t/1wi" />
-<a class="u-repost u-repost-of" href="http://example.com/webmention/target/placeholder" />
+  <a href="http://twitter.com/muhh/status/423756080376995840">retweeted this.</a><a class="u-repost-of" href="http://twitter.com/pfefferle/status/423744359297585152" />
+<a class="u-repost-of" href="http://notizblog.org/t/1wi" />
+<a class="u-repost-of" href="http://example.com/webmention/target/placeholder" />
   
   </div>
 

--- a/tests/data/mf2/sandeep-io.html
+++ b/tests/data/mf2/sandeep-io.html
@@ -81,7 +81,7 @@
 			<div class="h-entry">
 				<div class="post-box">
 					<div class="content">
-						<div>Liked a <a class="u-like" href="http://example.com/webmention/target/placeholder">post</a> by <a href="http://werd.io/profile/benwerd">Ben Werdmuller</a>.</div>
+						<div>Liked a <a class="u-like-of" href="http://example.com/webmention/target/placeholder">post</a> by <a href="http://werd.io/profile/benwerd">Ben Werdmuller</a>.</div>
 <p><blockquote>
 	<h1>What idno is</h1>
 


### PR DESCRIPTION
This addresses #444 and creates the 'update' comment type, indicating a source update notification. For now, it doesn't store it in the database, but it adds a hook for someone to add notifications or otherwise on it.

It also, as a precaution, adds a check for unregistered webmention comment types being added. This is to ensure if someone adds something custom to the map, they register it.