### PR TITLE
Add in default comment types

### DIFF
--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -62,7 +62,7 @@ class Comment {
 	 * @return boolean True if registered.
 	 */
 	public static function is_registered_comment_type( $slug ) {
-		return in_array( $slug, self::get_comment_type_names(), true );
+		return in_array( $slug, array_merge( self::get_comment_type_names(), array( 'comment', 'pingback', 'trackback' ) ), true );
 	}
 
 	/**

--- a/languages/webmention.pot
+++ b/languages/webmention.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: Webmention 5.2.0\n"
+"Project-Id-Version: Webmention 5.2.1\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wordpress-webmention\n"
-"POT-Creation-Date: 2023-12-25 21:46:11+00:00\n"
+"POT-Creation-Date: 2023-12-27 12:46:33+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Tags:** webmention, pingback, trackback, linkback, indieweb, comment, response  
 **Requires at least:** 4.9  
 **Tested up to:** 6.4  
-**Stable tag:** 5.2.0  
+**Stable tag:** 5.2.1  
 **Requires PHP:** 5.6  
 **License:** MIT  
 **License URI:** https://opensource.org/licenses/MIT  
@@ -99,10 +99,14 @@ While not all display options can be settings, we are looking to provide some si
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
 
+### 5.2.1 ###
+* Fix issue where built in comment types were rejected
+
 ### 5.2.0 ###
 
 * Do not bypass the spam filters
 * Support Source Update Notifications
+* Add in experimental Avatar Store
 
 ### 5.1.9 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://notiz.blog/donate/
 Tags: webmention, pingback, trackback, linkback, indieweb, comment, response
 Requires at least: 4.9
 Tested up to: 6.4
-Stable tag: 5.2.0
+Stable tag: 5.2.1
 Requires PHP: 5.6
 License: MIT
 License URI: https://opensource.org/licenses/MIT
@@ -99,10 +99,14 @@ While not all display options can be settings, we are looking to provide some si
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
 
+= 5.2.1 =
+* Fix issue where built in comment types were rejected
+
 = 5.2.0 =
 
 * Do not bypass the spam filters
 * Support Source Update Notifications
+* Add in experimental Avatar Store
 
 = 5.1.9 =
 

--- a/webmention.php
+++ b/webmention.php
@@ -5,7 +5,7 @@
  * Description: Webmention support for WordPress posts
  * Author: Matthias Pfefferle
  * Author URI: https://notiz.blog/
- * Version: 5.2.0
+ * Version: 5.2.1
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT
  * Text Domain: webmention


### PR DESCRIPTION
When I had it check for comment types, I forgot the built-in ones.