### PR TITLE
fix comment type detection

### DIFF
--- a/includes/Entity/class-item.php
+++ b/includes/Entity/class-item.php
@@ -321,7 +321,7 @@ class Item {
 		$response_type = $this->response_type ? $this->response_type : 'mention';
 		// Reclassify short mentions as comments
 		if ( 'mention' === $response_type ) {
-			$text     = $this->get_content();
+			$text     = $this->content;
 			$text_len = $this->str_length( $text );
 			if ( ( 0 < $text_len ) && ( $text_len <= MAX_INLINE_MENTION_LENGTH ) ) {
 				return 'comment';


### PR DESCRIPTION
Currently the `get_response_type` logic is using the `get_content` function. This function adds some fallbacks for mentions or for the case when the content is empty.

For `mentions` the `get_content` function always returns the summary that is smaller than `MAX_INLINE_MENTION_LENGTH`, so mentions will always be handled as comments.