### PR TITLE
Fix #396

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,27 @@
+.repost .dashboard-comment-wrap,
+.like .dashboard-comment-wrap,
+.favorite .dashboard-comment-wrap,
+.tag .dashboard-comment-wrap,
+.bookmark .dashboard-comment-wrap,
+.listen .dashboard-comment-wrap,
+.watch .dashboard-comment-wrap,
+.read .dashboard-comment-wrap,
+.follow .dashboard-comment-wrap,
+.mention .dashboard-comment-wrap,
+.reacji .dashboard-comment-wrap {
+	padding-inline-start: 63px;
+}
+
+.repost .dashboard-comment-wrap .comment-author,
+.like .dashboard-comment-wrap .comment-author,
+.favorite .dashboard-comment-wrap .comment-author,
+.tag .dashboard-comment-wrap .comment-author,
+.bookmark .dashboard-comment-wrap .comment-author,
+.listen .dashboard-comment-wrap .comment-author,
+.watch .dashboard-comment-wrap .comment-author,
+.read .dashboard-comment-wrap .comment-author,
+.follow .dashboard-comment-wrap .comment-author,
+.mention .dashboard-comment-wrap .comment-author,
+.reacji .dashboard-comment-wrap .comment-author {
+	margin-block: 0;
+}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -464,7 +464,7 @@ class Admin {
 	public static function enqueue_scripts() {
 		$current_screen = get_current_screen();
 		if ( isset( $current_screen->base ) && 'dashboard' === $current_screen->base ) {
-			wp_enqueue_style( 'webmention_admin', plugins_url( '/assets/css/admin.css', __DIR__ ), array(), version() );
+			wp_enqueue_style( 'webmention-admin', plugins_url( '/assets/css/admin.css', __DIR__ ), array(), version() );
 		}
 	}
 }

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -20,7 +20,7 @@ class Admin {
 
 		/* Add meta boxes on the 'add_meta_boxes' hook. */
 		add_action( 'add_meta_boxes', array( static::class, 'add_meta_boxes' ) );
-
+		add_action( 'admin_enqueue_scripts', array( static::class, 'enqueue_scripts' ) );
 		add_filter( 'plugin_action_links', array( static::class, 'plugin_action_links' ), 10, 2 );
 		add_filter( 'plugin_row_meta', array( static::class, 'plugin_row_meta' ), 10, 2 );
 
@@ -455,6 +455,16 @@ class Admin {
 
 		if ( function_exists( 'wp_add_privacy_policy_content' ) ) {
 			wp_add_privacy_policy_content( __( 'Webmention', 'webmention' ), $content );
+		}
+	}
+
+	/**
+	 * Enqueue admin styles.
+	 */
+	public static function enqueue_scripts() {
+		$current_screen = get_current_screen();
+		if ( isset( $current_screen->base ) && 'dashboard' === $current_screen->base ) {
+			wp_enqueue_style( 'webmention_admin', plugins_url( '/assets/css/admin.css', __DIR__ ), array(), version() );
 		}
 	}
 }


### PR DESCRIPTION
Adds a single CSS file on the admin dashboard only, which I believe makes the "custom" comment types look more like WordPress' default comments (in the dashboard's "Activity" panel).

Tested (only) on my own live site (for different comment types, with and without avatar). Seems to work :-P