### PR TITLE
Fix #470

### DIFF
--- a/includes/class-comment-walker.php
+++ b/includes/class-comment-walker.php
@@ -291,12 +291,8 @@ class Comment_Walker extends Walker_Comment {
 			return;
 		}
 
-		if ( ! empty( $query->query_vars['meta_query'] ) ) {
-			$query = current( $query->query_vars['meta_query'] );
-
-			if ( ! empty( $query['key'] ) && 'protocol' === $query['key'] ) {
-				return;
-			}
+		if ( ! empty( $query->query_vars['meta_query']['key'] ) && 'protocol' === $query->query_vars['meta_query']['key'] ) {
+			return;
 		}
 
 		if ( isset( $query->query_vars['count'] ) && true === $query->query_vars['count'] ) {


### PR DESCRIPTION
By reassigning `$query`, you break most that comes after.

Also, `current( $query->query_vars['meta_query'] )` _can_ return a string ... [See the example in the docs](https://developer.wordpress.org/reference/classes/wp_comment_query/#comment-2032), where `current( $query->query_vars['meta_query'] )` would return `'AND'`:
```
$args = array(
	'meta_query' => array(
		'relation' => 'AND',
		array(
			'key' => 'featured',
			'value' => '1'
		),
		array(
			'key' => 'buried',
			'value' => '1',
			'type' => 'numeric',
			'compare' => '!='
		)
	)
 );
```

But in general, `$query`, which is passed to the callback by reference, should not be reassigned.