### PR TITLE
Allow "Approve & Always Allow" only for Webmentions

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -203,7 +203,11 @@ class Admin {
 		}
 
 		if ( 'unapproved' === $status ) {
-			$actions['domainapprovelist'] = sprintf( '<a href="%1$s" aria-label="%2$s">%2$s</a>', esc_url( $approve_url ), esc_attr__( 'Approve & Always Allow', 'webmention' ) );
+			$actions['domainapprovelist'] = sprintf(
+				'<a href="%1$s" aria-label="%2$s">%2$s</a>',
+				esc_url( $approve_url ),
+				esc_attr__( 'Approve & Always Allow', 'webmention' )
+			);
 		}
 
 		return $actions;

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -195,11 +195,17 @@ class Admin {
 
 		$approve_url = admin_url( 'comment.php' );
 		$approve_url = add_query_arg( $query, $approve_url );
+		$status      = wp_get_comment_status( $comment );
+		$protocol    = get_comment_meta( $comment->comment_ID, 'protocol' );
 
-		$status = wp_get_comment_status( $comment );
+		if ( ! $protocol || ! in_array( 'webmention', $protocol, true ) ) {
+			return $actions;
+		}
+
 		if ( 'unapproved' === $status ) {
 			$actions['domainapprovelist'] = sprintf( '<a href="%1$s" aria-label="%2$s">%2$s</a>', esc_url( $approve_url ), esc_attr__( 'Approve & Always Allow', 'webmention' ) );
 		}
+
 		return $actions;
 	}
 


### PR DESCRIPTION
This fails on other comment types like for example ActivityPub: https://github.com/Automattic/wordpress-activitypub/issues/865