### PR TITLE
Check for missing format property

### DIFF
--- a/includes/class-comment-walker.php
+++ b/includes/class-comment-walker.php
@@ -109,6 +109,11 @@ class Comment_Walker extends Walker_Comment {
 			add_filter( 'comment_text', array( $this, 'filter_comment_text' ), 40, 2 );
 		}
 
+		// ClassicPress cut the comment method and defaults to html5. So this will ensure that html5_comment is always called
+		if ( ! method_exists( $this, 'comment' ) || ! array_key_exists( 'format', $args ) ) {
+			$args['format'] = 'html5';
+		}
+
 		// Maintain the original pingback and trackback output.
 		if ( ( 'pingback' === $comment->comment_type || 'trackback' === $comment->comment_type ) && $args['short_ping'] ) {
 			ob_start();


### PR DESCRIPTION
ClassicPress defaults to HTML5, so removed the regular comment function and the format argument. I've opened a bug that they should have kept backcompat on this...having the comment function call the html5 function. This just defaults to HTML5 if no format is set...being as html5 is supposed to default if nothing is set per the WP docs, this should be fine.