### PR TITLE
Add classic editor fallback for webmention post settings

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -52,17 +52,27 @@ class Admin {
 	}
 
 	/**
-	 * Add Webmention meta boxes to the comment editor screen.
+	 * Add Webmention meta boxes to the omment editor screen.
 	 *
 	 * @param object $object The comment object.
 	 */
-	public static function meta_boxes( $object ) {
+	public static function comment_metabox( $object ) {
 		wp_nonce_field( 'webmention_comment_metabox', 'webmention_comment_nonce' );
 
 		if ( ! $object instanceof WP_Comment ) {
 			return;
 		}
 		load_template( __DIR__ . '/../templates/webmention-edit-comment-form.php' );
+	}
+
+	/**
+	 * Add Webmention settings meta box to the Classic editor screen.
+	 *
+	 * @param object $object The comment object.
+	 */
+	public static function post_metabox( $object ) {
+		wp_nonce_field( 'webmention_post_metabox', 'webmention_post_nonce' );
+		load_template( __DIR__ . '/../templates/webmention-edit-post-form.php' );
 	}
 
 	/**
@@ -162,10 +172,22 @@ class Admin {
 		add_meta_box(
 			'webmention-meta',
 			esc_html__( 'Webmention Data', 'webmention' ),
-			array( static::class, 'meta_boxes' ),
+			array( static::class, 'comment_metabox' ),
 			'comment',
 			'normal',
 			'default'
+		);
+		add_meta_box(
+			'webmention-meta',
+			esc_html__( 'Webmention Settings', 'webmention' ),
+			array( static::class, 'post_metabox' ),
+			get_option( 'webmention_support_post_types', array( 'post', 'page' ) ),
+			'side',
+			'default',
+			array(
+				'__block_editor_compatible_meta_box' => true,
+				'__back_compat_meta_box'             => true, // This should only be used in the Classic Editor.
+			)
 		);
 	}
 

--- a/includes/class-block.php
+++ b/includes/class-block.php
@@ -9,34 +9,6 @@ class Block {
 	public static function init() {
 		// Add editor plugin.
 		\add_action( 'enqueue_block_editor_assets', array( self::class, 'enqueue_editor_assets' ) );
-		\add_action( 'init', array( self::class, 'register_postmeta' ), 11 );
-	}
-
-	/**
-	 * Register post meta
-	 */
-	public static function register_postmeta() {
-		$post_types = \get_post_types_by_support( 'webmentions' );
-		foreach ( $post_types as $post_type ) {
-			\register_post_meta(
-				$post_type,
-				'webmentions_disabled',
-				array(
-					'show_in_rest' => true,
-					'single'       => true,
-					'type'         => 'boolean',
-				)
-			);
-			\register_post_meta(
-				$post_type,
-				'webmentions_disabled_pings',
-				array(
-					'show_in_rest' => true,
-					'single'       => true,
-					'type'         => 'boolean',
-				)
-			);
-		}
 	}
 
 	/**

--- a/templates/webmention-edit-post-form.php
+++ b/templates/webmention-edit-post-form.php
@@ -1,0 +1,13 @@
+<?php $post_id = get_the_ID(); ?>
+<fieldset><ul>
+	<li>
+	<input type="hidden" name="webmentions_disabled" value="0" />
+	<input type="checkbox" class="widefat" name="webmentions_disabled" id="webmentions_disabled" value="1" <?php checked( 1, get_post_meta( $post_id, 'webmentions_disabled', 1 ) ); ?> />
+	<label><?php esc_html_e( 'Disable Incoming', 'webmention' ); ?></label>
+	<legend><sub><?php _e( 'Do Not Accept incoming Webmentions for this post', 'webmention' ); ?></sub></legend><li>
+	<li>
+	<input type="hidden" name="webmentions_disabled_pings" value="0" />
+	<input type="checkbox" class="widefat" name="webmentions_disabled_pings" id="webmentions_disabled_pings" value="1" <?php checked( 1, intval( get_post_meta( $post_id, 'webmentions_disabled_pings', 1 ) ) ); ?> />
+	<label><?php esc_html_e( 'Disable Outgoing', 'webmention' ); ?></label>
+	<legend><sub><?php _e( 'Do Not send outgoing Webmentions for this post', 'webmention' ); ?></sub></legend></li>
+</fieldset>


### PR DESCRIPTION
Addresses #527 

Moved the meta settings to receiver and sender functions, consistent with early design, as they aren't block specific any longer. It sets up a metabox that will appear only in the Classic Editor and Classic Press.