### PR TITLE
Fix: Implement nickname fallback for mf2 parser

### DIFF
--- a/includes/Handler/class-mf2.php
+++ b/includes/Handler/class-mf2.php
@@ -112,6 +112,15 @@ class MF2 extends Base {
 			foreach ( array( 'name', 'nickname', 'given-name', 'family-name', 'url', 'email', 'photo' ) as $prop ) {
 				$author[ $prop ] = $this->get_plaintext( $properties, $prop );
 			}
+
+			// If name is not available, use nickname or the combination of given name and family name as fallback
+			if ( empty( $author['name'] ) ) {
+				if ( ! empty( $author['nickname'] ) ) {
+					$author['name'] = $author['nickname'];
+				} elseif ( ! empty( $author['given-name'] ) || ! empty( $author['family-name'] ) ) {
+					$author['name'] = implode( ' ', array_filter( array( $author['given-name'], $author['family-name'] ) ) );
+				}
+			}
 		}
 
 		$this->webmention_item->add_author( array_filter( $author ) );

--- a/tests/data/mf2/brid-gy-mastodon.html
+++ b/tests/data/mf2/brid-gy-mastodon.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="0;url=https://aseachange.com/@elena/statuses/01JZNGNC6TXX9QYZ3Q13ZK31C7">
+<title><p><span class="h-card"><a href="https://mastodon.social/@pfefferle" class="u-url mention" rel="nofollow noopener" target="_blank">@<span>pfefferle</span></a></span> such a fast solution wow! 🏆✨ congrats all</p><p><span class="h-card"><a href="https://social.wake.st/@liaizon" class="u-url mention" rel="nofollow noopener" target="_blank">@<span>liaizon</span></a></span> <span class="h-card"><a href="https://snac.rohrmoser.name/social/wake_st" class="u-url mention" rel="nofollow noopener" target="_blank">@<span>wake_st</span></a></span> <span class="h-card"><a href="https://notiz.blog/author/matthias-pfefferle/" class="u-url mention" rel="nofollow noopener" target="_blank">@<span>pfefferle</span></a></span> <span class="h-card"><a href="https://comam.es/snac/grunfink" class="u-url mention" rel="nofollow noopener" target="_blank">@<span>grunfink</span></a></span></p></title>
+<style type="text/css">
+body {
+  display: none;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+.p-uid {
+  display: none;
+}
+.u-photo {
+  max-width: 50px;
+  border-radius: 4px;
+}
+.e-content {
+  margin-top: 10px;
+  font-size: 1.3em;
+}
+</style>
+</head>
+<article class="h-entry">
+  <span class="p-uid">https://aseachange.com/users/elena/statuses/01JZNGNC6TXX9QYZ3Q13ZK31C7</span>
+
+  <time class="dt-published" datetime="2025-07-08T17:17:15+00:00">2025-07-08T17:17:15+00:00</time>
+
+  <span class="p-author h-card">
+    <data class="p-uid" value="https://aseachange.com/users/elena"></data>
+<data class="p-numeric-id" value="113695878928179087"></data>
+    <a class="p-name u-url" href="https://aseachange.com/@elena">Elena Rossini on GoToSocial ⁂</a>
+<a class="u-url" href="https://news.elenarossini.com"></a>
+<a class="u-url" href="https://elena.social"></a>
+    <span class="p-nickname">elena</span>
+    <img class="u-photo" src="https://files.mastodon.social/cache/accounts/avatars/113/695/878/928/179/087/original/edadee646dc7593c.jpeg" alt="" />
+  </span>
+
+  <a title="aseachange.com/@elena/statuses/01JZNGNC6TXX9QYZ3Q13ZK31C7" class="u-url" href="https://aseachange.com/@elena/statuses/01JZNGNC6TXX9QYZ3Q13ZK31C7">aseachange.com/@elena/statuse...</a>
+  <div class="e-content p-name">
+
+  <p><span class="h-card"><a href="https://mastodon.social/@pfefferle" class="u-url mention" rel="nofollow noopener" target="_blank">@<span>pfefferle</span></a></span> such a fast solution wow! 🏆✨ congrats all</p><p><span class="h-card"><a href="https://social.wake.st/@liaizon" class="u-url mention" rel="nofollow noopener" target="_blank">@<span>liaizon</span></a></span> <span class="h-card"><a href="https://snac.rohrmoser.name/social/wake_st" class="u-url mention" rel="nofollow noopener" target="_blank">@<span>wake_st</span></a></span> <span class="h-card"><a href="https://notiz.blog/author/matthias-pfefferle/" class="u-url mention" rel="nofollow noopener" target="_blank">@<span>pfefferle</span></a></span> <span class="h-card"><a href="https://comam.es/snac/grunfink" class="u-url mention" rel="nofollow noopener" target="_blank">@<span>grunfink</span></a></span></p>
+  </div>
+
+
+
+
+  <span class="u-category h-card">
+    <data class="p-uid" value="https://mastodon.social/users/pfefferle"></data>
+    <a class="p-name u-url" href="https://mastodon.social/@pfefferle">pfefferle</a>
+
+
+  </span>
+
+  <span class="u-category h-card">
+    <data class="p-uid" value="https://social.wake.st/users/liaizon"></data>
+    <a class="p-name u-url" href="https://social.wake.st/@liaizon">liaizon</a>
+
+
+  </span>
+
+  <span class="u-category h-card">
+    <data class="p-uid" value="https://snac.rohrmoser.name/social/wake_st"></data>
+    <a class="p-name u-url" href="https://snac.rohrmoser.name/social/wake_st">wake_st</a>
+
+
+  </span>
+
+  <span class="u-category h-card">
+    <data class="p-uid" value="https://notiz.blog/author/matthias-pfefferle/"></data>
+    <a class="p-name u-url" href="https://notiz.blog/author/matthias-pfefferle/">pfefferle</a>
+
+
+  </span>
+
+  <span class="u-category h-card">
+    <data class="p-uid" value="https://comam.es/snac/grunfink"></data>
+    <a class="p-name u-url" href="https://comam.es/snac/grunfink">grunfink</a>
+
+
+  </span>
+
+  <a class="u-in-reply-to" href="https://mastodon.social/web/statuses/114818494113762375"></a>
+  <a class="u-in-reply-to" href="tag:mastodon.social,2013:114818494113762375"></a>
+
+
+</article>
+
+</html>

--- a/tests/data/mf2/brid-gy-mastodon.json
+++ b/tests/data/mf2/brid-gy-mastodon.json
@@ -1,0 +1,7 @@
+{
+  "author": {
+    "name": "elena",
+    "url": "https://aseachange.com/users/elena"
+  },
+  "response_type": "mention"
+}


### PR DESCRIPTION
The current code seems to parse the `nickname`, but there is no fallback implemented. This PR tries to fall back to `nickname` and `given-name` + `family-name` if `name` is empty.

This fixes fed.brid.gy webmentions.

<img width="896" alt="Screenshot 2025-07-09 at 09 33 02" src="https://github.com/user-attachments/assets/aada83ca-f7a4-4d1e-aa84-0d298e87f3a6" />
