### PR TITLE
Fix undefined property warning in Item::__call magic method

### DIFF
--- a/includes/entity/class-item.php
+++ b/includes/entity/class-item.php
@@ -115,11 +115,11 @@ class Item {
 		$var = strtolower( substr( $method, 4 ) );
 
 		if ( strncasecmp( $method, 'get', 3 ) === 0 ) {
-			return $this->$var;
+			return property_exists( $this, $var ) ? $this->$var : '';
 		}
 
 		if ( strncasecmp( $method, 'has', 3 ) === 0 ) {
-			return ! empty( $this->$var );
+			return property_exists( $this, $var ) && ! empty( $this->$var );
 		}
 
 		if ( strncasecmp( $method, 'set', 3 ) === 0 ) {
@@ -127,7 +127,7 @@ class Item {
 		}
 
 		if ( strncasecmp( $method, 'add', 3 ) === 0 ) {
-			if ( ! $this->$var ) {
+			if ( ! property_exists( $this, $var ) || ! $this->$var ) {
 				call_user_func( array( $this, 'set_' . $var ), current( $params ) );
 				return true;
 			}

--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,7 @@ Project and support maintained on github at [pfefferle/wordpress-webmention](htt
 
 ### 5.6.0
 
+* Fix undefined property warning in `Item::__call` magic method when accessing non-existent properties like `category`.
 * Search Avatar Store if enabled for match before trying meta field. Disable updating meta field when side loading allowing for more flexibility.
 * Fix editor plugin error on custom post types without `custom-fields` support.
 * Add video/audio URL extraction as content fallback for webmentions without text content.


### PR DESCRIPTION
## Summary
- Add `property_exists()` checks before accessing dynamic properties in `get`, `has`, and `add` methods
- Prevents PHP warnings when methods like `add_category()` are called for properties that don't exist on the class

## Test plan
- [ ] Verify no more "Undefined property" warnings at `/wp-json/webmention/1.0/endpoint`
- [ ] Test webmention processing still works correctly

Fixes #541