### PR TITLE
Fix blind SSRF via unsafe remote requests

### DIFF
--- a/includes/class-tools.php
+++ b/includes/class-tools.php
@@ -78,7 +78,7 @@ class Tools {
 		$target = $request->get_param( 'target' );
 		$mode   = $request->get_param( 'mode' );
 
-		$response = Request::get( $source, false );
+		$response = Request::get( $source );
 
 		if ( is_wp_error( $response ) ) {
 			return $response;

--- a/includes/handler/class-mf2.php
+++ b/includes/handler/class-mf2.php
@@ -875,7 +875,7 @@ class MF2 extends Base {
 	 * @return WP_Error|array Return error or author array if successful.
 	 */
 	public function parse_authorpage( $url ) {
-		$response = Request::get( $url, false );
+		$response = Request::get( $url );
 
 		if ( is_wp_error( $response ) ) {
 			return $response;


### PR DESCRIPTION
## Summary
- Fix unauthenticated blind SSRF vulnerability in Webmention handling
- `parse_authorpage()` in `class-mf2.php` and `Tools::read()` in `class-tools.php` were calling `Request::get($url, false)` which uses `wp_remote_get()` (unsafe) instead of `wp_safe_remote_get()`
- Attacker-controlled source pages could include mf2 `rel=author` links pointing to internal services (127.0.0.1, 169.254.x.x, etc.), causing server-side requests to internal/private IPs
- Changed both call sites to use `Request::get($url)` (defaults to `safe=true`), which uses `wp_safe_remote_get()` with WordPress's built-in URL validation and private IP blocking

## Test plan
- [ ] Verify Webmentions with external author URLs still work correctly
- [ ] Verify author pages on public URLs are still fetched and parsed
- [ ] Confirm requests to internal IPs (127.0.0.1, 10.x, 192.168.x) are blocked
- [ ] Test the tools page source reading still works with public URLs