### PR TITLE
Disable webmentions for non-production environments

### DIFF
--- a/includes/class-response.php
+++ b/includes/class-response.php
@@ -187,6 +187,10 @@ class Response {
 			$body = mb_convert_encoding( $body, 'HTML-ENTITIES', mb_detect_encoding( $body ) );
 		}
 
+		if ( empty( $body ) ) {
+			return new WP_Error( 'empty_body', __( 'Request body has no data', 'webmention' ) );
+		}
+
 		$dom_document = new DOMDocument();
 		$dom_document->loadHTML( $body );
 

--- a/includes/class-webmention.php
+++ b/includes/class-webmention.php
@@ -95,6 +95,27 @@ class Webmention {
 	}
 
 	/**
+	 * Check if Webmentions should be disabled for the current environment.
+	 *
+	 * By default, Webmentions are disabled for 'local', 'development',
+	 * and 'staging' environments.
+	 *
+	 * @return bool Whether Webmentions are disabled for the current environment.
+	 */
+	public static function is_disabled_for_environment() {
+		$environment_type = \wp_get_environment_type();
+		$disabled         = \in_array( $environment_type, array( 'local', 'development', 'staging' ), true );
+
+		/**
+		 * Filter whether Webmentions should be disabled for the current environment.
+		 *
+		 * @param bool   $disabled         Whether Webmentions are disabled.
+		 * @param string $environment_type  The current environment type.
+		 */
+		return \apply_filters( 'webmention_disable_for_environment', $disabled, $environment_type );
+	}
+
+	/**
 	 * Register hooks.
 	 */
 	public function register_hooks() {
@@ -108,14 +129,17 @@ class Webmention {
 		// load HTTP 410 support.
 		\add_action( 'init', array( HTTP_Gone::class, 'init' ) );
 
-		// initialize Webmention Sender.
-		\add_action( 'init', array( Sender::class, 'init' ) );
+		// Disable sending, receiving, and discovery for non-production environments.
+		if ( ! self::is_disabled_for_environment() ) {
+			// initialize Webmention Sender.
+			\add_action( 'init', array( Sender::class, 'init' ) );
 
-		// initialize Webmention Receiver.
-		\add_action( 'init', array( Receiver::class, 'init' ) );
+			// initialize Webmention Receiver.
+			\add_action( 'init', array( Receiver::class, 'init' ) );
 
-		// initialize Webmention Discovery.
-		\add_action( 'init', array( Discovery::class, 'init' ) );
+			// initialize Webmention Discovery.
+			\add_action( 'init', array( Discovery::class, 'init' ) );
+		}
 
 		if ( site_supports_blocks() ) {
 			// initialize Webmention Bloks.


### PR DESCRIPTION
## Summary

- Disables webmention sending, receiving, and discovery when `WP_ENVIRONMENT_TYPE` is `local`, `development`, or `staging`
- Production and unset environments remain unaffected (default WordPress behavior treats unset as `production`)
- Adds a `webmention_disable_for_environment` filter that receives the disable boolean and the environment type string, allowing developers to override

## Test plan

- [ ] Set `WP_ENVIRONMENT_TYPE` to `local` and verify no webmentions are sent or received, and discovery headers are absent
- [ ] Set `WP_ENVIRONMENT_TYPE` to `production` (or leave unset) and verify webmentions work normally
- [ ] Use the `webmention_disable_for_environment` filter to override the default behavior (e.g., force-enable on staging)
- [ ] Verify other plugin features (comments, avatars, blocks, admin) still work on non-production environments

Fixes #588