### PR TITLE
Guard against empty body in DOMDocument::loadHTML()

### DIFF
--- a/includes/class-response.php
+++ b/includes/class-response.php
@@ -187,6 +187,10 @@ class Response {
 			$body = mb_convert_encoding( $body, 'HTML-ENTITIES', mb_detect_encoding( $body ) );
 		}
 
+		if ( empty( $body ) ) {
+			return new WP_Error( 'empty_body', __( 'Request body has no data', 'webmention' ) );
+		}
+
 		$dom_document = new DOMDocument();
 		$dom_document->loadHTML( $body );
 


### PR DESCRIPTION
## Summary
- Adds an `empty()` check after `mb_convert_encoding()` in `Response::get_dom_document()` to prevent a `ValueError` when `DOMDocument::loadHTML()` receives an empty string on PHP 8.1+.
- The existing `! $body` check guards against empty input, but `mb_convert_encoding()` can return an empty string in edge cases (e.g., encoding detection failure), bypassing that guard.

Fixes #332

## Test plan
- [ ] Verify that a post with empty `post_content` does not trigger a `ValueError` from `DOMDocument::loadHTML()`
- [ ] Verify that normal webmention sending still works for posts with content