### PR TITLE
Prefix webmention_canonical_url meta key with underscore

### DIFF
--- a/includes/class-sender.php
+++ b/includes/class-sender.php
@@ -142,7 +142,7 @@ class Sender {
 	public static function trash_post( $post_id ) {
 		add_post_meta(
 			$post_id,
-			'webmention_canonical_url',
+			'_webmention_canonical_url',
 			get_permalink( $post_id ),
 			true
 		);
@@ -156,7 +156,7 @@ class Sender {
 	 * @return void
 	 */
 	public static function untrash_post( $post_id ) {
-		delete_post_meta( $post_id, 'webmention_canonical_url' );
+		delete_post_meta( $post_id, '_webmention_canonical_url' );
 	}
 
 	/**
@@ -237,7 +237,7 @@ class Sender {
 			return;
 		}
 
-		$source = get_post_meta( $post_id, 'webmention_canonical_url', true );
+		$source = get_post_meta( $post_id, '_webmention_canonical_url', true );
 
 		if ( ! $source ) {
 			$source = get_permalink( $post_id );

--- a/includes/class-upgrade.php
+++ b/includes/class-upgrade.php
@@ -110,6 +110,9 @@ class Upgrade {
 		if ( version_compare( $version_from_db, '1.0.1', '<' ) ) {
 			self::migrate_to_1_0_1();
 		}
+		if ( version_compare( $version_from_db, '1.0.2', '<' ) ) {
+			self::migrate_to_1_0_2();
+		}
 
 		/**
 		 * Fires when the system has to be migrated.
@@ -122,6 +125,24 @@ class Upgrade {
 		\update_option( 'webmention_db_version', WEBMENTION_VERSION );
 
 		self::unlock();
+	}
+
+	/**
+	 * Rename post meta keys.
+	 *
+	 * @param string $old_key The old postmeta key.
+	 * @param string $new_key The new postmeta key.
+	 */
+	public static function update_postmeta_key( $old_key, $new_key ) {
+		global $wpdb;
+
+		$wpdb->update(
+			$wpdb->postmeta,
+			array( 'meta_key' => $new_key ),
+			array( 'meta_key' => $old_key ),
+			array( '%s' ),
+			array( '%s' )
+		);
 	}
 
 	/**
@@ -225,5 +246,19 @@ class Upgrade {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Migrate to version 1.0.2
+	 *
+	 * Prefix the `webmention_canonical_url` post meta key with an underscore
+	 * so it is hidden from the Custom Fields UI dropdown.
+	 *
+	 * @since 5.8.0
+	 *
+	 * @return void
+	 */
+	public static function migrate_to_1_0_2() {
+		self::update_postmeta_key( 'webmention_canonical_url', '_webmention_canonical_url' );
 	}
 }

--- a/includes/class-upgrade.php
+++ b/includes/class-upgrade.php
@@ -110,8 +110,8 @@ class Upgrade {
 		if ( version_compare( $version_from_db, '1.0.1', '<' ) ) {
 			self::migrate_to_1_0_1();
 		}
-		if ( version_compare( $version_from_db, '1.0.2', '<' ) ) {
-			self::migrate_to_1_0_2();
+		if ( version_compare( $version_from_db, '5.7.0', '<' ) ) {
+			self::migrate_to_5_7_0();
 		}
 
 		/**
@@ -249,16 +249,16 @@ class Upgrade {
 	}
 
 	/**
-	 * Migrate to version 1.0.2
+	 * Migrate to version 5.7.0
 	 *
 	 * Prefix the `webmention_canonical_url` post meta key with an underscore
 	 * so it is hidden from the Custom Fields UI dropdown.
 	 *
-	 * @since 5.8.0
+	 * @since 5.7.0
 	 *
 	 * @return void
 	 */
-	public static function migrate_to_1_0_2() {
+	public static function migrate_to_5_7_0() {
 		self::update_postmeta_key( 'webmention_canonical_url', '_webmention_canonical_url' );
 	}
 }

--- a/includes/class-upgrade.php
+++ b/includes/class-upgrade.php
@@ -110,8 +110,8 @@ class Upgrade {
 		if ( version_compare( $version_from_db, '1.0.1', '<' ) ) {
 			self::migrate_to_1_0_1();
 		}
-		if ( version_compare( $version_from_db, '5.7.0', '<' ) ) {
-			self::migrate_to_5_7_0();
+		if ( version_compare( $version_from_db, '5.8.2', '<' ) ) {
+			self::migrate_to_5_8_2();
 		}
 
 		/**
@@ -249,16 +249,18 @@ class Upgrade {
 	}
 
 	/**
-	 * Migrate to version 5.7.0
+	 * Migrate to version 5.8.2
 	 *
 	 * Prefix the `webmention_canonical_url` post meta key with an underscore
 	 * so it is hidden from the Custom Fields UI dropdown.
 	 *
-	 * @since 5.7.0
+	 * @since 5.8.2
 	 *
 	 * @return void
 	 */
-	public static function migrate_to_5_7_0() {
+	public static function migrate_to_5_8_2() {
+		wp_cache_flush();
+
 		self::update_postmeta_key( 'webmention_canonical_url', '_webmention_canonical_url' );
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 - Tags: webmention, pingback, trackback, linkback, indieweb
 - Requires at least: 6.2
 - Tested up to: 7.0
-- Stable tag: 5.8.1
+- Stable tag: 5.8.2
 - Requires PHP: 7.4
 - License: MIT
 - License URI: https://opensource.org/licenses/MIT
@@ -100,6 +100,10 @@ While not all display options can be settings, we are looking to provide some si
 ## Changelog
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+### 5.8.2
+
+* Prefix the `webmention_canonical_url` post meta key with an underscore so it is hidden from the Custom Fields UI, with a migration to rename existing entries
 
 ### 5.8.1
 

--- a/tests/phpunit/tests/class-test-upgrade.php
+++ b/tests/phpunit/tests/class-test-upgrade.php
@@ -54,4 +54,21 @@ class Test_Upgrade extends WP_UnitTestCase {
 		$this->assertEquals( $comment->comment_type, 'reply' );
 		$this->assertEquals( $comment->comment_author_url, 'https://example.org/author_url' );
 	}
+
+	/**
+	 * Test that the 5.7.0 migration prefixes the canonical URL meta key.
+	 */
+	public function test_migrate_to_5_7_0_prefixes_canonical_url_meta_key() {
+		$post_id = self::factory()->post->create();
+
+		add_post_meta( $post_id, 'webmention_canonical_url', 'https://example.org/canonical', true );
+
+		\Webmention\Upgrade::migrate_to_5_7_0();
+
+		// The cached meta needs to be refreshed after the direct database update.
+		wp_cache_flush();
+
+		$this->assertSame( '', get_post_meta( $post_id, 'webmention_canonical_url', true ), 'The old meta key should no longer exist.' );
+		$this->assertSame( 'https://example.org/canonical', get_post_meta( $post_id, '_webmention_canonical_url', true ), 'The value should be stored under the prefixed key.' );
+	}
 }

--- a/tests/phpunit/tests/class-test-upgrade.php
+++ b/tests/phpunit/tests/class-test-upgrade.php
@@ -56,17 +56,14 @@ class Test_Upgrade extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the 5.7.0 migration prefixes the canonical URL meta key.
+	 * Test that the 5.8.2 migration prefixes the canonical URL meta key.
 	 */
-	public function test_migrate_to_5_7_0_prefixes_canonical_url_meta_key() {
+	public function test_migrate_to_5_8_2_prefixes_canonical_url_meta_key() {
 		$post_id = self::factory()->post->create();
 
 		add_post_meta( $post_id, 'webmention_canonical_url', 'https://example.org/canonical', true );
 
-		\Webmention\Upgrade::migrate_to_5_7_0();
-
-		// The cached meta needs to be refreshed after the direct database update.
-		wp_cache_flush();
+		\Webmention\Upgrade::migrate_to_5_8_2();
 
 		$this->assertSame( '', get_post_meta( $post_id, 'webmention_canonical_url', true ), 'The old meta key should no longer exist.' );
 		$this->assertSame( 'https://example.org/canonical', get_post_meta( $post_id, '_webmention_canonical_url', true ), 'The value should be stored under the prefixed key.' );

--- a/webmention.php
+++ b/webmention.php
@@ -5,7 +5,7 @@
  * Description: Webmention support for WordPress posts
  * Author: Matthias Pfefferle
  * Author URI: https://notiz.blog/
- * Version: 5.8.1
+ * Version: 5.8.2
  * Requires at least: 6.2
  * Requires PHP: 7.4
  * License: MIT
@@ -16,7 +16,7 @@
 
 namespace Webmention;
 
-\define( 'WEBMENTION_VERSION', '5.8.1' );
+\define( 'WEBMENTION_VERSION', '5.8.2' );
 
 \define( 'WEBMENTION_PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 \define( 'WEBMENTION_PLUGIN_BASENAME', \plugin_basename( __FILE__ ) );


### PR DESCRIPTION
## Summary

- Renames the `webmention_canonical_url` post meta key to `_webmention_canonical_url` so it is hidden from the Custom Fields UI dropdown (meta keys prefixed with `_` are treated as internal by WordPress)
- Adds a reusable `Upgrade::update_postmeta_key()` helper for renaming post meta keys
- Adds a database migration gated on `5.8.2` that renames the meta key for existing entries, and bumps the plugin to `5.8.2`
- Adds a regression test covering the migration

Fixes #493

## Version gating

`webmention_db_version` stores the **plugin** version (`maybe_upgrade()` writes `WEBMENTION_VERSION` after migrating), and 5.7.0 / 5.8.0 / 5.8.1 are all released. A migration gated below the current release would never run on existing installs, so the guard is set to the next unreleased version, `5.8.2`, and the plugin version is bumped to match. The migration also calls `wp_cache_flush()` (like the existing `migrate_to_1_0_0()` / `migrate_to_1_0_1()`) so persistent-cache installs don't read stale post meta after the direct `$wpdb->update`.

## Test plan

- [x] Automated test: the migration renames existing `webmention_canonical_url` entries in `wp_postmeta` to `_webmention_canonical_url` (`test_migrate_to_5_8_2_prefixes_canonical_url_meta_key`)
- [ ] Manually verify the meta key no longer appears in the Custom Fields dropdown on the post editor
- [ ] Manually verify delete webmentions still work for trashed posts (source URL retrieved from the prefixed meta key)

## Notes

- Rebased/merged with latest `main`; full suite passing and PHPCS clean.