### PR TITLE
Add nomention CSS class support to exclude links from Webmentions

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -343,12 +343,27 @@ function webmention_extract_urls( $content, $support_media_urls = false ) {
 		$attributes = array_merge( $attributes, $media_attributes );
 	}
 
+	/**
+	 * Filters the CSS class name used to prevent sending Webmentions for a link.
+	 *
+	 * @param string $nomention_class The CSS class name. Default 'nomention'.
+	 */
+	$nomention_class = apply_filters( 'webmention_nomention_class', 'nomention' );
+
 	$urls = array();
 
 	foreach ( $attributes as $attribute => $elements ) {
 		foreach ( $elements as $element ) {
-			foreach ( $xpath->query( sprintf( '//%1$s[@%2$s]', $element, $attribute ) ) as $url ) {
-				$urls[] = $url->getAttribute( $attribute );
+			foreach ( $xpath->query( sprintf( '//%1$s[@%2$s]', $element, $attribute ) ) as $node ) {
+				// Skip elements that have the nomention class.
+				if ( $nomention_class && $node->hasAttribute( 'class' ) ) {
+					$classes = preg_split( '/\s+/', $node->getAttribute( 'class' ) );
+					if ( in_array( $nomention_class, $classes, true ) ) {
+						continue;
+					}
+				}
+
+				$urls[] = $node->getAttribute( $attribute );
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Adds support for a `nomention` CSS class on links (`<a class="nomention">`) to prevent Webmentions from being sent for those URLs
- Filters out elements with the `nomention` class during URL extraction in `webmention_extract_urls()`
- Adds a `webmention_nomention_class` filter so developers can customize the class name

Closes #166

## Test plan

- [ ] Create a post with a mix of normal links and links with `class="nomention"`
- [ ] Verify that only the normal links trigger Webmentions
- [ ] Verify that the `webmention_nomention_class` filter can override the default class name
- [ ] Run `composer lint` to confirm coding standards compliance