### PR TITLE
Apply theme styles on "Ping me!" button

### DIFF
--- a/templates/comment-form.php
+++ b/templates/comment-form.php
@@ -13,7 +13,7 @@ do_action( 'webmention_comment_form_template_before' );
 		<input id="webmention-source" class="webmention-source" type="url" autocomplete="url" required pattern="^https?:\/\/(.*)" name="source" aria-describedby="webmention-source-description" />
 	</p>
 	<p>
-		<input id="webmention-submit" class="wp-element-button" type="submit" name="submit" value="<?php echo esc_attr( apply_filters( 'webmention_form_submit_text', __( 'Ping me!', 'webmention' ) ) ); ?>" />
+		<input id="webmention-submit" class="wp-element-button wp-block-button__link" type="submit" name="submit" value="<?php echo esc_attr( apply_filters( 'webmention_form_submit_text', __( 'Ping me!', 'webmention' ) ) ); ?>" />
 	</p>
 	<input id="webmention-format" type="hidden" name="format" value="html" />
 	<input id="webmention-target" type="hidden" name="target" value="<?php the_permalink(); ?>" />


### PR DESCRIPTION
The button currently only has the `.wp-element-button` class. In order to pick the default styles of the theme for a button, it also needs to have the `.wp-block-button__link` class on the input (see the normal "Comment" button as a reference). This change makes sure both buttons look the same.