### PR TITLE
Bump minimum PHP version to 7.4 and prepare 5.8.0

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -30,10 +30,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.4', '8.3', '8.5']
+        php-versions: ['7.4', '8.3', '8.5']
         wp-version: ['latest']
         include:
-          - php-versions: '7.2'
+          - php-versions: '7.4'
             wp-version: '6.2'
           - php-versions: '8.5'
             wp-version: 'trunk'

--- a/composer-php-scoper.json
+++ b/composer-php-scoper.json
@@ -2,7 +2,7 @@
   "name": "pfefferle/wordpress-webmention",
   "description": "A Webmention plugin for WordPress https://wordpress.org/plugins/webmention/",
   "require": {
-    "php": ">=7.0"
+    "php": ">=7.4"
   },
   "type": "wordpress-plugin",
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "pfefferle/wordpress-webmention",
   "description": "A Webmention plugin for WordPress https://wordpress.org/plugins/webmention/",
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.4",
     "composer/installers": "^1.0 || ^2.0"
   },
   "type": "wordpress-plugin",
@@ -18,7 +18,7 @@
   },
   "require-dev": {
     "mf2/mf2": "^0.5.0",
-    "phpunit/phpunit": "^8 || ^9 || ^10",
+    "phpunit/phpunit": "^9 || ^10",
     "phpcompatibility/php-compatibility": "*",
     "phpcompatibility/phpcompatibility-wp": "*",
     "squizlabs/php_codesniffer": "3.*",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -25,7 +25,7 @@
 
 	<!-- Rules: Check PHP Compatibility -->
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="7.2-"/>
+	<config name="testVersion" value="7.4-"/>
 
 	<!-- Rules: WordPress Coding Standards -->
 	<rule ref="WordPress-Core"/>

--- a/readme.md
+++ b/readme.md
@@ -5,8 +5,8 @@
 - Tags: webmention, pingback, trackback, linkback, indieweb
 - Requires at least: 6.2
 - Tested up to: 7.0
-- Stable tag: 5.7.0
-- Requires PHP: 7.2
+- Stable tag: 5.8.0
+- Requires PHP: 7.4
 - License: MIT
 - License URI: https://opensource.org/licenses/MIT
 
@@ -100,6 +100,11 @@ While not all display options can be settings, we are looking to provide some si
 ## Changelog
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+### 5.8.0
+
+* Bump minimum required PHP version to 7.4
+* Fix `ValueError` in `DOMDocument::loadHTML()` when the post content is empty on PHP 8.1+
 
 ### 5.7.0
 

--- a/webmention.php
+++ b/webmention.php
@@ -5,7 +5,9 @@
  * Description: Webmention support for WordPress posts
  * Author: Matthias Pfefferle
  * Author URI: https://notiz.blog/
- * Version: 5.7.0
+ * Version: 5.8.0
+ * Requires at least: 6.2
+ * Requires PHP: 7.4
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT
  * Text Domain: webmention
@@ -14,7 +16,7 @@
 
 namespace Webmention;
 
-\define( 'WEBMENTION_VERSION', '5.7.0' );
+\define( 'WEBMENTION_VERSION', '5.8.0' );
 
 \define( 'WEBMENTION_PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 \define( 'WEBMENTION_PLUGIN_BASENAME', \plugin_basename( __FILE__ ) );


### PR DESCRIPTION
## Summary

Raises the minimum required PHP version from 7.2 to 7.4 and prepares the 5.8.0 release.

### Changes

- **`readme.md`**: `Requires PHP: 7.4`, `Stable tag: 5.8.0`, new 5.8.0 changelog section (PHP bump + empty-content `loadHTML()` fix from #596)
- **`webmention.php`**: version bumped to 5.8.0 (header and `WEBMENTION_VERSION`); adds the previously missing `Requires at least` and `Requires PHP` plugin headers, which WordPress core uses for activation guards and `wp webmention meta` reads
- **`composer.json`**: `php >=7.4`; PHPUnit constraint narrowed to `^9 || ^10` (PHPUnit 8 was only kept for PHP 7.2)
- **`composer-php-scoper.json`**: `php >=7.0` → `>=7.4`
- **`phpcs.xml`**: PHPCompatibility `testVersion` `7.2-` → `7.4-`
- **`.github/workflows/phpunit.yml`**: PHP 7.2 dropped from the test matrix; the WordPress 6.2 job now runs on PHP 7.4

### Testing

- `composer lint` passes, including PHPCompatibility against the new 7.4 baseline
- PHPUnit runs in CI across PHP 7.4 / 8.3 / 8.5