### PR TITLE
Improve Webmention endpoint response messages

### DIFF
--- a/includes/class-receiver.php
+++ b/includes/class-receiver.php
@@ -430,8 +430,11 @@ class Receiver {
 		// disable flood control
 		remove_action( 'check_comment_flood', 'check_comment_flood_db', 10 );
 
+		// if the comment ID is set, the Webmention already exists and will be updated
+		$is_update = ! empty( $commentdata['comment_ID'] );
+
 		// update or save webmention
-		if ( empty( $commentdata['comment_ID'] ) ) {
+		if ( ! $is_update ) {
 			if ( ! is_array( $commentdata['comment_meta'] ) ) {
 				$commentdata['comment_meta'] = array();
 			}
@@ -479,13 +482,29 @@ class Receiver {
 		// re-add flood control
 		add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
 
+		if ( $is_update ) {
+			/**
+			 * Filters the message that is returned when a Webmention already exists and was updated.
+			 *
+			 * @param string $message The update message.
+			 */
+			$message = apply_filters( 'webmention_update_message', esc_html__( 'Thanks! You already sent a Webmention for this post, so we updated the existing one with the latest information.', 'webmention' ) );
+		} else {
+			/**
+			 * Filters the message that is returned when a Webmention was received successfully.
+			 *
+			 * @param string $message The success message.
+			 */
+			$message = apply_filters( 'webmention_success_message', esc_html__( 'Webmention was successful', 'webmention' ) );
+		}
+
 		// Return select data
 		$return = array(
 			'link'    => get_comment_link( $commentdata['comment_ID'] ),
 			'source'  => $commentdata['source'],
 			'target'  => $commentdata['target'],
 			'code'    => 'success',
-			'message' => apply_filters( 'webmention_success_message', esc_html__( 'Webmention was successful', 'webmention' ) ),
+			'message' => $message,
 		);
 
 		return new WP_REST_Response( $return, 200 );

--- a/includes/class-receiver.php
+++ b/includes/class-receiver.php
@@ -409,7 +409,7 @@ class Receiver {
 				'source'  => $commentdata['source'],
 				'target'  => $commentdata['target'],
 				'code'    => 'success',
-				'message' => apply_filters( 'webmention_success_message', esc_html__( 'Webmention was successful', 'webmention' ) ),
+				'message' => apply_filters( 'webmention_success_message', esc_html__( 'Thank you! Your Webmention has been received.', 'webmention' ) ),
 			);
 			return new WP_REST_Response( $return, 200 );
 		}
@@ -488,14 +488,14 @@ class Receiver {
 			 *
 			 * @param string $message The update message.
 			 */
-			$message = apply_filters( 'webmention_update_message', esc_html__( 'Thanks! You already sent a Webmention for this post, so we updated the existing one with the latest information.', 'webmention' ) );
+			$message = apply_filters( 'webmention_update_message', esc_html__( 'You already sent a Webmention for this target. The existing Webmention has been updated.', 'webmention' ) );
 		} else {
 			/**
 			 * Filters the message that is returned when a Webmention was received successfully.
 			 *
 			 * @param string $message The success message.
 			 */
-			$message = apply_filters( 'webmention_success_message', esc_html__( 'Webmention was successful', 'webmention' ) );
+			$message = apply_filters( 'webmention_success_message', esc_html__( 'Thank you! Your Webmention has been received.', 'webmention' ) );
 		}
 
 		// Return select data

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,11 @@ While not all display options can be settings, we are looking to provide some si
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
 
+### 5.8.0
+
+* Return a distinct message when a Webmention already exists and was updated, filterable via `webmention_update_message`
+* Friendlier default success message for the Webmention endpoint
+
 ### 5.7.0
 
 * Fix blind SSRF vulnerability by using `wp_safe_remote_get` for author page and tools requests


### PR DESCRIPTION
## Summary

Fixes #176

When a Webmention is received for a source/target combination that already exists, `check_dupes()` matches the existing comment and the endpoint updates it — but it still responded with **"Webmention was successful"**. Users who had already sent a Webmention natively and then tried the form on the target page found this confusing.

### Changes

- The update path now returns its own message: *"You already sent a Webmention for this target. The existing Webmention has been updated."* — filterable via the new `webmention_update_message` hook.
- The default success message is friendlier: *"Thank you! Your Webmention has been received."* (both in the regular success response and the `target-update` path; still filterable via `webmention_success_message`).

### Note on the trim() warning quoted in the issue

The `trim() expects parameter 1 to be string, array given` warning in the issue's quoted output comes from the deprecated semantic-linkbacks plugin, not from this codebase. An audit of this plugin's equivalent paths (mf2 handler, response/header parsing, sanitization) found the same failure class is already guarded against, so there is nothing to fix here.