### PR TITLE
Fix stored XSS via unescaped Webmention-derived comment meta

### DIFF
--- a/includes/class-receiver.php
+++ b/includes/class-receiver.php
@@ -68,27 +68,30 @@ class Receiver {
 			);
 		}
 		$args = array(
-			'type'         => 'string',
-			'description'  => esc_html__( 'Protocol Used to Receive', 'webmention' ),
-			'single'       => true,
-			'show_in_rest' => true,
+			'type'              => 'string',
+			'description'       => esc_html__( 'Protocol Used to Receive', 'webmention' ),
+			'single'            => true,
+			'show_in_rest'      => true,
+			'sanitize_callback' => 'sanitize_key',
 		);
 		register_meta( 'comment', 'protocol', $args );
 
 		$args = array(
-			'type'         => 'string',
-			'description'  => esc_html__( 'Target URL for the Webmention', 'webmention' ),
-			'single'       => true,
-			'show_in_rest' => true,
+			'type'              => 'string',
+			'description'       => esc_html__( 'Target URL for the Webmention', 'webmention' ),
+			'single'            => true,
+			'show_in_rest'      => true,
+			'sanitize_callback' => 'esc_url_raw',
 		);
 		register_meta( 'comment', 'webmention_target_url', $args );
 
 		// For pingbacks the source URL is stored in the author URL. This means you cannot have an author URL that is different than the source.
 		$args = array(
-			'type'         => 'string',
-			'description'  => esc_html__( 'Source URL for the Webmention', 'webmention' ),
-			'single'       => true,
-			'show_in_rest' => true,
+			'type'              => 'string',
+			'description'       => esc_html__( 'Source URL for the Webmention', 'webmention' ),
+			'single'            => true,
+			'show_in_rest'      => true,
+			'sanitize_callback' => 'esc_url_raw',
 		);
 		register_meta( 'comment', 'webmention_source_url', $args );
 
@@ -102,10 +105,11 @@ class Receiver {
 
 		// Purpose of this is to store the original time as there is no modified time in the comment table.
 		$args = array(
-			'type'         => 'string',
-			'description'  => esc_html__( 'Last Modified Time for the Webmention (GMT)', 'webmention' ),
-			'single'       => true,
-			'show_in_rest' => true,
+			'type'              => 'string',
+			'description'       => esc_html__( 'Last Modified Time for the Webmention (GMT)', 'webmention' ),
+			'single'            => true,
+			'show_in_rest'      => true,
+			'sanitize_callback' => 'sanitize_text_field',
 		);
 		register_meta( 'comment', 'webmention_last_modified', $args );
 
@@ -120,26 +124,29 @@ class Receiver {
 
 		// Purpose of this is to store a vouch URL
 		$args = array(
-			'type'         => 'string',
-			'description'  => esc_html__( 'Webmention Vouch URL', 'webmention' ),
-			'single'       => true,
-			'show_in_rest' => true,
+			'type'              => 'string',
+			'description'       => esc_html__( 'Webmention Vouch URL', 'webmention' ),
+			'single'            => true,
+			'show_in_rest'      => true,
+			'sanitize_callback' => 'esc_url_raw',
 		);
 		register_meta( 'comment', 'webmention_vouch_url', $args );
 
 		$args = array(
-			'type'         => 'string',
-			'description'  => esc_html__( 'Canonical URL for the Webmention', 'webmention' ),
-			'single'       => true,
-			'show_in_rest' => true,
+			'type'              => 'string',
+			'description'       => esc_html__( 'Canonical URL for the Webmention', 'webmention' ),
+			'single'            => true,
+			'show_in_rest'      => true,
+			'sanitize_callback' => 'esc_url_raw',
 		);
 		register_meta( 'comment', 'url', $args );
 
 		$args = array(
-			'type'         => 'string',
-			'description'  => esc_html__( 'Avatar URL', 'webmention' ),
-			'single'       => true,
-			'show_in_rest' => true,
+			'type'              => 'string',
+			'description'       => esc_html__( 'Avatar URL', 'webmention' ),
+			'single'            => true,
+			'show_in_rest'      => true,
+			'sanitize_callback' => 'esc_url_raw',
 		);
 		register_meta( 'comment', 'avatar', $args );
 	}

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 - Tags: webmention, pingback, trackback, linkback, indieweb
 - Requires at least: 6.2
 - Tested up to: 7.0
-- Stable tag: 5.8.0
+- Stable tag: 5.8.1
 - Requires PHP: 7.4
 - License: MIT
 - License URI: https://opensource.org/licenses/MIT
@@ -100,6 +100,12 @@ While not all display options can be settings, we are looking to provide some si
 ## Changelog
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+### 5.8.1
+
+* Security: Fix a stored XSS reachable from unauthenticated Webmentions where parser-derived author metadata (avatar, URL) was rendered unescaped in the comment edit metabox
+* Security: Sanitize Webmention comment meta on store via `register_meta` sanitize callbacks (`esc_url_raw` for URL meta, `sanitize_key`/`sanitize_text_field` for the rest) to keep the database clean
+* Security: Escape remaining template output (comment edit metabox, single-comment view, endpoint message and form, reaction headings)
 
 ### 5.8.0
 

--- a/templates/api-message.php
+++ b/templates/api-message.php
@@ -116,7 +116,7 @@
 	</style>
 	</head>
 	<body id="webmention-endpint-page">
-		<p><?php echo $data['message']; ?></p>
+		<p><?php echo esc_html( $data['message'] ); ?></p>
 
 		<p id="backtoblog"><a href="<?php echo esc_url( home_url( '/' ) ); ?>">
 			<?php

--- a/templates/comment-form.php
+++ b/templates/comment-form.php
@@ -4,7 +4,7 @@
  */
 do_action( 'webmention_comment_form_template_before' );
 ?>
-<form id="webmention-form" action="<?php echo get_webmention_endpoint(); ?>" method="post">
+<form id="webmention-form" action="<?php echo esc_url( get_webmention_endpoint() ); ?>" method="post">
 	<p id="webmention-source-description">
 		<?php echo get_webmention_form_text( get_the_ID() ); ?>
 	</p>

--- a/templates/comment.php
+++ b/templates/comment.php
@@ -45,7 +45,7 @@ if ( $comment->comment_parent ) {
 		<script type="text/javascript">
 			<!--
 			// redirect to comment-page and scroll to comment
-			window.location = "<?php echo get_permalink( $comment->comment_post_ID ) . '#comment-' . $comment->comment_ID; ?>";
+			window.location = "<?php echo esc_url( get_permalink( $comment->comment_post_ID ) . '#comment-' . $comment->comment_ID ); ?>";
 			//–>
 		</script>
 	</head>
@@ -73,7 +73,7 @@ if ( $comment->comment_parent ) {
 					</time></a>
 					<ul>
 					<?php if ( $target ) { ?>
-						<li><a href="<?php echo $target; ?>" rel="in-reply-to" class="u-in-reply-to u-reply-of"><?php echo $target; ?></a></li>
+						<li><a href="<?php echo esc_url( $target ); ?>" rel="in-reply-to" class="u-in-reply-to u-reply-of"><?php echo esc_html( $target ); ?></a></li>
 					<?php } ?>
 					</ul>
 				</footer>

--- a/templates/comments.php
+++ b/templates/comments.php
@@ -18,7 +18,7 @@ foreach ( $grouped_mentions as $mention_type => $mentions ) {
 	}
 	?>
 
-<h2><?php echo get_webmention_comment_type_attr( $mention_type, 'label' ); ?></h2>
+<h2><?php echo esc_html( get_webmention_comment_type_attr( $mention_type, 'label' ) ); ?></h2>
 <ul class="reaction-list reaction-list--<?php echo esc_attr( $mention_type ); ?>">
 	<?php
 	if ( ( $fold_limit > 0 ) && $fold_limit < count( $mentions ) ) {

--- a/templates/edit-comment-form.php
+++ b/templates/edit-comment-form.php
@@ -1,25 +1,25 @@
 <?php global $comment; ?>
 <label><?php esc_html_e( 'Comment Type', 'webmention' ); ?></label>
-<input type="url" class="widefat" disabled value="<?php echo get_webmention_comment_type_string( $comment ); ?>" />
+<input type="url" class="widefat" disabled value="<?php echo esc_attr( get_webmention_comment_type_string( $comment ) ); ?>" />
 <br />
 <?php if ( 'webmention' === get_comment_meta( $comment->comment_ID, 'protocol', true ) ) { ?>
 	<label><?php esc_html_e( 'Target', 'webmention' ); ?></label>
-	<input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $comment->comment_ID, 'webmention_target_url', true ); ?>" />
+	<input type="url" class="widefat" disabled value="<?php echo esc_url( get_comment_meta( $comment->comment_ID, 'webmention_target_url', true ) ); ?>" />
 	<br />
 
 	<label><?php esc_html_e( 'Source', 'webmention' ); ?></label>
-	<input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $comment->comment_ID, 'webmention_source_url', true ); ?>" />
+	<input type="url" class="widefat" disabled value="<?php echo esc_url( get_comment_meta( $comment->comment_ID, 'webmention_source_url', true ) ); ?>" />
 	<br />
 
 	<label><?php esc_html_e( 'Avatar', 'webmention' ); ?></label>
-	<input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $comment->comment_ID, 'avatar', true ); ?>" />
+	<input type="url" class="widefat" disabled value="<?php echo esc_url( get_comment_meta( $comment->comment_ID, 'avatar', true ) ); ?>" />
 	<br />
 
 	<label><?php esc_html_e( 'Canonical URL', 'webmention' ); ?></label>
-	<input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $comment->comment_ID, 'url', true ); ?>" />
+	<input type="url" class="widefat" disabled value="<?php echo esc_url( get_comment_meta( $comment->comment_ID, 'url', true ) ); ?>" />
 	<br />
 
 	<label><?php esc_html_e( 'Creation Time', 'webmention' ); ?></label>
-	<input type="url" class="widefat" disabled value="<?php echo get_comment_meta( $comment->comment_ID, 'webmention_created_at', true ); ?>" />
+	<input type="url" class="widefat" disabled value="<?php echo esc_attr( get_comment_meta( $comment->comment_ID, 'webmention_created_at', true ) ); ?>" />
 	<br />
 <?php } ?>

--- a/templates/endpoint-form.php
+++ b/templates/endpoint-form.php
@@ -123,7 +123,7 @@
 
 		<?php do_action( 'webmention_endpoint_form_before_form' ); ?>
 
-		<form id="webmention-form" action="<?php echo get_webmention_endpoint(); ?>" method="post">
+		<form id="webmention-form" action="<?php echo esc_url( get_webmention_endpoint() ); ?>" method="post">
 			<?php do_action( 'webmention_endpoint_form_before_input_fields' ); ?>
 			<p>
 				<label for="webmention-source"><?php esc_html_e( 'Source URL', 'webmention' ); ?>:</label><br />

--- a/tests/phpunit/tests/class-test-admin-metabox.php
+++ b/tests/phpunit/tests/class-test-admin-metabox.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Test the Webmention comment edit metabox.
+ *
+ * @package Webmention
+ */
+
+use Webmention\WP_Admin\Admin;
+
+/**
+ * Test the Webmention comment edit metabox for stored XSS regressions.
+ */
+class Test_Admin_Metabox extends WP_UnitTestCase {
+	/**
+	 * An attribute-breaking payload as supplied through parsed Webmention metadata.
+	 *
+	 * @var string
+	 */
+	const XSS_PAYLOAD = 'https://attacker.invalid/avatar.jpg" /><script>alert(1)</script><input value="';
+
+	/**
+	 * Render the comment metabox for a given comment.
+	 *
+	 * @param WP_Comment $comment The comment to render the metabox for.
+	 *
+	 * @return string The captured metabox HTML.
+	 */
+	private function render_metabox( $comment ) {
+		$GLOBALS['comment'] = $comment;
+		ob_start();
+		Admin::comment_metabox( $comment );
+		$output = ob_get_clean();
+		unset( $GLOBALS['comment'] );
+
+		return $output;
+	}
+
+	/**
+	 * The URL meta should be sanitized with esc_url_raw before it is stored.
+	 */
+	public function test_url_meta_is_sanitized_on_store() {
+		$comment_id = self::factory()->comment->create();
+
+		foreach ( array( 'avatar', 'url', 'webmention_source_url', 'webmention_target_url' ) as $meta_key ) {
+			add_comment_meta( $comment_id, $meta_key, self::XSS_PAYLOAD, true );
+			$stored = get_comment_meta( $comment_id, $meta_key, true );
+
+			$this->assertStringNotContainsString( '<script>', $stored, "Stored {$meta_key} must not contain a script tag." );
+			$this->assertStringNotContainsString( '"', $stored, "Stored {$meta_key} must not contain a double quote." );
+			$this->assertStringNotContainsString( '<', $stored, "Stored {$meta_key} must not contain an angle bracket." );
+		}
+	}
+
+	/**
+	 * Even a raw (pre-sanitization) value in the database must be escaped on output.
+	 */
+	public function test_metabox_escapes_unsanitized_meta_on_output() {
+		global $wpdb;
+
+		$comment_id = self::factory()->comment->create();
+		update_comment_meta( $comment_id, 'protocol', 'webmention' );
+
+		// Simulate a legacy row written before the sanitize callback existed by
+		// inserting the raw payload directly, bypassing the sanitize callback.
+		$wpdb->insert(
+			$wpdb->commentmeta,
+			array(
+				'comment_id' => $comment_id,
+				'meta_key'   => 'avatar',
+				'meta_value' => self::XSS_PAYLOAD,
+			)
+		);
+		wp_cache_delete( $comment_id, 'comment_meta' );
+
+		// Confirm the unescaped payload really is in the database.
+		$this->assertSame( self::XSS_PAYLOAD, get_comment_meta( $comment_id, 'avatar', true ) );
+
+		$output = $this->render_metabox( get_comment( $comment_id ) );
+
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $output, 'The metabox must not emit an unescaped script tag.' );
+		$this->assertStringNotContainsString( 'value="' . self::XSS_PAYLOAD . '"', $output, 'The raw payload must not break out of the value attribute.' );
+	}
+}

--- a/webmention.php
+++ b/webmention.php
@@ -5,7 +5,7 @@
  * Description: Webmention support for WordPress posts
  * Author: Matthias Pfefferle
  * Author URI: https://notiz.blog/
- * Version: 5.8.0
+ * Version: 5.8.1
  * Requires at least: 6.2
  * Requires PHP: 7.4
  * License: MIT
@@ -16,7 +16,7 @@
 
 namespace Webmention;
 
-\define( 'WEBMENTION_VERSION', '5.8.0' );
+\define( 'WEBMENTION_VERSION', '5.8.1' );
 
 \define( 'WEBMENTION_PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 \define( 'WEBMENTION_PLUGIN_BASENAME', \plugin_basename( __FILE__ ) );


### PR DESCRIPTION
## Summary

Fixes a stored XSS reachable from **unauthenticated** Webmentions. Parser-derived author metadata (`avatar`, `url`) from a crafted source page was stored unsanitized and rendered unescaped into HTML `value` attributes in the comment edit metabox. When a moderator/administrator opens the comment, an attribute-breaking payload executes JavaScript in their privileged wp-admin session.

Source → sink:
- `includes/handler/class-mf2.php` parses attacker-controlled `u-photo` / `u-url` (no validation)
- `includes/entity/class-item.php` stores them as `avatar` / `url` comment meta
- `templates/edit-comment-form.php` echoed them raw into `value="..."`

The meta was **not** sanitized on store either — `register_meta()` had no `sanitize_callback`.

## Fix (defense in depth)

**Sanitize on store** — added `register_meta()` sanitize callbacks in `class-receiver.php`:
- `esc_url_raw` for URL meta: `avatar`, `url`, `webmention_source_url`, `webmention_target_url`, `webmention_vouch_url`
- `sanitize_key` for `protocol`, `sanitize_text_field` for `webmention_last_modified`
- Left `webmention_target_fragment` / `webmention_response_code` / `webmention_vouched` untouched — they feed dedupe meta-queries/comparisons and are never rendered to HTML.

**Escape on output** — escaped every field in `edit-comment-form.php` plus other unescaped template sinks found while auditing:
- `templates/comment.php` — `comment_author_url` was echoed raw into an `href` **and** link text on a public page (a second XSS vector) → `esc_url` / `esc_html`
- `api-message.php`, `comments.php`, `comment-form.php`, `endpoint-form.php`

Output escaping is needed independently because sanitize callbacks only apply to new writes; already-stored rows still need escaping on render.

## Tests

- New `tests/phpunit/tests/class-test-admin-metabox.php` covers storage sanitization and output escaping. Confirmed it **fails against the unfixed code** (emits a live `<script>` breakout) and **passes** with the fix.
- Full suite: **73 tests, 117 assertions, all passing** (via wp-env). Changed lines lint clean.

## Version

Bumped to **5.8.1** (5.8.0 is already released) with changelog entries.