### PR TITLE
Stop repeated Webmentions on unchanged posts

### DIFF
--- a/includes/class-sender.php
+++ b/includes/class-sender.php
@@ -262,12 +262,28 @@ class Sender {
 		$mentioned = get_post_meta( $post->ID, '_webmentioned', true );
 		$mentioned = empty( $mentioned ) ? array() : $mentioned;
 
-		// Find previously sent Webmentions and send them one last time.
+		// Detect whether the post content changed since the last send. Re-sending the
+		// same, unchanged post to already-notified targets caused the repeated
+		// Webmentions reported in https://github.com/pfefferle/wordpress-webmention/issues/619.
+		$content_hash    = md5( $post->post_content );
+		$last_hash       = get_post_meta( $post->ID, '_webmention_content_hash', true );
+		$content_changed = ( $content_hash !== $last_hash );
+
+		// Find previously sent Webmentions that are no longer linked and send them one last time.
 		$deletes = array_diff( $mentioned, $targets );
+
+		// When the content changed, notify every current target so receivers re-fetch the
+		// updated post. Otherwise only (re)send to targets we have not yet confirmed as sent,
+		// which lets HTTP 5xx retries through while skipping already-notified targets.
+		if ( $content_changed ) {
+			$to_send = $targets;
+		} else {
+			$to_send = array_diff( $targets, $mentioned );
+		}
 
 		$mentions = array();
 
-		foreach ( $targets as $target ) {
+		foreach ( $to_send as $target ) {
 			// send Webmention
 			$response = self::send_webmention( $source, $target, $post_id );
 
@@ -286,6 +302,9 @@ class Sender {
 			}
 		}
 
+		// Deletes that fail with a 5xx are retained so the delete is retried next run.
+		$retained_deletes = array();
+
 		foreach ( $deletes as $deleted ) {
 			// send delete Webmention
 			$response = self::send_webmention( $source, $deleted, $post_id );
@@ -293,18 +312,30 @@ class Sender {
 			// reschedule if server responds with a http error 5xx
 			if ( wp_remote_retrieve_response_code( $response ) >= 500 ) {
 				self::reschedule( $post_id );
-				$mentions[] = $deleted;
+				$retained_deletes[] = $deleted;
 			}
 		}
 
-		if ( ! empty( $mentions ) ) {
-			update_post_meta( $post_id, '_webmentioned', $mentions );
-		}
+		// Persist the set of notified targets: previously notified targets that are still
+		// linked, plus targets notified this run, plus deletes still awaiting retry.
+		$notified = array_values(
+			array_unique(
+				array_merge(
+					array_intersect( $mentioned, $targets ),
+					$mentions,
+					$retained_deletes
+				)
+			)
+		);
 
-		$pung = get_pung( $post );
+		update_post_meta( $post->ID, '_webmentioned', $notified );
+		update_post_meta( $post->ID, '_webmention_content_hash', $content_hash );
 
-		if ( ! empty( $ping ) ) {
-			self::update_ping( $post, array_merge( $pung, $ping ) );
+		// Keep WordPress' own `pinged` list in sync so the core pinging subsystem does
+		// not treat these links as un-pinged.
+		if ( ! empty( $notified ) ) {
+			$pung = get_pung( $post );
+			self::update_ping( $post, array_values( array_unique( array_merge( $pung, $notified ) ) ) );
 		}
 
 		return $mentions;

--- a/includes/class-sender.php
+++ b/includes/class-sender.php
@@ -316,12 +316,18 @@ class Sender {
 			}
 		}
 
-		// Persist the set of notified targets: previously notified targets that are still
-		// linked, plus targets notified this run, plus deletes still awaiting retry.
+		// On a content change every target is re-sent, so only targets confirmed this run
+		// count as notified; a previously-notified target that fails must be retried, not
+		// carried forward. On unchanged content the targets we did not re-send this run
+		// remain notified.
+		$carried = $content_changed ? array() : array_intersect( $mentioned, $targets );
+
+		// Persist the set of notified targets: carried-forward targets, plus targets
+		// notified this run, plus deletes still awaiting retry.
 		$notified = array_values(
 			array_unique(
 				array_merge(
-					array_intersect( $mentioned, $targets ),
+					$carried,
 					$mentions,
 					$retained_deletes
 				)

--- a/tests/phpunit/tests/class-test-sender.php
+++ b/tests/phpunit/tests/class-test-sender.php
@@ -108,6 +108,127 @@ class Test_Sender extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that unchanged content does not re-send Webmentions.
+	 *
+	 * Regression test for repeated Webmentions (issue #619): once a target has
+	 * been successfully notified, re-running the sender for the same, unchanged
+	 * post must not send the Webmention again.
+	 */
+	public function test_send_webmentions_does_not_resend_unchanged_content() {
+		$request_count = 0;
+
+		add_filter(
+			'webmention_server_url',
+			function () {
+				return 'https://example.com/webmention';
+			}
+		);
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$request_count ) {
+				// Only count the actual Webmention POST, not endpoint discovery.
+				if ( 'https://example.com/webmention' === $url ) {
+					++$request_count;
+				}
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => 'Webmention received',
+				);
+			},
+			10,
+			3
+		);
+
+		// First run should send the Webmention.
+		Sender::send_webmentions( $this->post->ID );
+		$this->assertSame( 1, $request_count, 'First run should send one Webmention.' );
+
+		// Second run with unchanged content must not send it again.
+		Sender::send_webmentions( $this->post->ID );
+		$this->assertSame( 1, $request_count, 'Unchanged content must not re-send the Webmention.' );
+	}
+
+	/**
+	 * Test that changed content re-sends Webmentions to the new targets.
+	 */
+	public function test_send_webmentions_resends_when_content_changes() {
+		$requested_targets = array();
+
+		add_filter(
+			'webmention_server_url',
+			function () {
+				return 'https://example.com/webmention';
+			}
+		);
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$requested_targets ) {
+				// Only record the actual Webmention POST, not endpoint discovery.
+				if ( 'https://example.com/webmention' === $url && ! empty( $args['body'] ) ) {
+					parse_str( $args['body'], $parsed );
+					if ( isset( $parsed['target'] ) ) {
+						$requested_targets[] = rawurldecode( $parsed['target'] );
+					}
+				}
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => 'Webmention received',
+				);
+			},
+			10,
+			3
+		);
+
+		// First run notifies the original link.
+		Sender::send_webmentions( $this->post->ID );
+		$this->assertSame( array( 'https://example.com' ), $requested_targets );
+
+		// Add a new link to the post content.
+		wp_update_post(
+			array(
+				'ID'           => $this->post->ID,
+				'post_content' => 'Test post with links to <a href="https://example.com">Example</a> and <a href="https://example.org">Example Org</a>',
+			)
+		);
+		$requested_targets = array();
+
+		Sender::send_webmentions( $this->post->ID );
+		$this->assertContains( 'https://example.org', $requested_targets, 'A newly added link must be notified.' );
+	}
+
+	/**
+	 * Test that the post `pinged` column is populated after sending.
+	 *
+	 * Regression test for the dead "restore update punged" block that referenced
+	 * an undefined `$ping` variable and therefore never updated `pinged`.
+	 */
+	public function test_send_webmentions_updates_pinged() {
+		add_filter(
+			'webmention_server_url',
+			function () {
+				return 'https://example.com/webmention';
+			}
+		);
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => 'Webmention received',
+				);
+			}
+		);
+
+		Sender::send_webmentions( $this->post->ID );
+
+		$pinged = get_pung( $this->post->ID );
+		$this->assertContains( 'https://example.com', $pinged, 'Successfully sent targets must be recorded in `pinged`.' );
+	}
+
+	/**
 	 * Test send webmentions with error response.
 	 */
 	public function test_send_webmentions_with_error_response() {

--- a/tests/phpunit/tests/class-test-sender.php
+++ b/tests/phpunit/tests/class-test-sender.php
@@ -199,6 +199,62 @@ class Test_Sender extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a target which fails during a content-change re-send is retried.
+	 *
+	 * A previously-notified target that returns HTTP 5xx while the post content is
+	 * being re-sent must not be recorded as notified, so the rescheduled run still
+	 * retries it instead of treating it as already delivered.
+	 */
+	public function test_send_webmentions_retries_target_that_fails_during_content_change() {
+		$response_code = 200;
+
+		add_filter(
+			'webmention_server_url',
+			function () {
+				return 'https://example.com/webmention';
+			}
+		);
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$response_code ) {
+				// Endpoint discovery must always succeed; only the POST reflects the code.
+				if ( 'https://example.com/webmention' === $url ) {
+					return array(
+						'response' => array( 'code' => $response_code ),
+						'body'     => 'Webmention received',
+					);
+				}
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => 'Webmention received',
+				);
+			},
+			10,
+			3
+		);
+
+		// First run succeeds, so the target is recorded as notified.
+		Sender::send_webmentions( $this->post->ID );
+		$this->assertContains( 'https://example.com', get_post_meta( $this->post->ID, '_webmentioned', true ) );
+
+		// Change the content so the sender re-notifies every target, but the re-send fails.
+		wp_update_post(
+			array(
+				'ID'           => $this->post->ID,
+				'post_content' => 'Updated body linking to <a href="https://example.com">Example</a>',
+			)
+		);
+		$response_code = 500;
+
+		Sender::send_webmentions( $this->post->ID );
+
+		$mentioned = get_post_meta( $this->post->ID, '_webmentioned', true );
+		$mentioned = empty( $mentioned ) ? array() : $mentioned;
+		$this->assertNotContains( 'https://example.com', $mentioned, 'A target that fails during a content-change re-send must not be marked as notified.' );
+	}
+
+	/**
 	 * Test that the post `pinged` column is populated after sending.
 	 *
 	 * Regression test for the dead "restore update punged" block that referenced


### PR DESCRIPTION
Fixes #619.

## Problem

The plugin re-sends the same Webmentions to the same targets repeatedly (reporters saw them ~10–15 minutes apart, indefinitely). Two related issues in `Sender::send_webmentions()`:

1. **No idempotency guard.** Every time the `_mentionme` flag is set, the loop re-sends to *every* current link. `_mentionme` gets re-added on **any save of a published post** (which a caching/republish plugin can trigger) and via the **5xx reschedule** path — whose interval is `tries × 900s`, i.e. the 15-minute steps that were observed.

2. **Dead `pinged`-tracking code.** The block meant to record successful sends referenced an undefined `$ping` variable (a leftover from a `$ping` → `$mentions` rename in 525549c, reintroduced by c3da954 "Restore update punged"). So `! empty( $ping )` was always false and the post's `pinged` column was never updated — matching the report that successful sends "never make it to the meta entry."

## Fix

- Track a content hash in `_webmention_content_hash`. On **unchanged** content, only (re)send to targets not yet confirmed sent — so already-notified links are skipped (stopping the flood) while genuine 5xx retries still get through. On **changed** content, notify all current targets so receivers re-fetch the update.
- Restore the `pinged` update using the real notified-targets list.
- Preserve delete-Webmention retry-on-5xx behavior.

## Tests

Added regression tests (written test-first):
- `test_send_webmentions_does_not_resend_unchanged_content`
- `test_send_webmentions_resends_when_content_changes`
- `test_send_webmentions_updates_pinged`

Full suite: 76/76 passing; PHPCS clean on `class-sender.php`.