### PR TITLE
Release 5.9.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 - Tags: webmention, pingback, trackback, linkback, indieweb
 - Requires at least: 6.2
 - Tested up to: 7.0
-- Stable tag: 5.8.1
+- Stable tag: 5.9.0
 - Requires PHP: 7.4
 - License: MIT
 - License URI: https://opensource.org/licenses/MIT
@@ -100,6 +100,14 @@ While not all display options can be settings, we are looking to provide some si
 ## Changelog
 
 Project and support maintained on github at [pfefferle/wordpress-webmention](https://github.com/pfefferle/wordpress-webmention).
+
+### 5.9.0
+
+* Add a reaction picker to the block editor link popover for marking a link as a reply, like, repost, bookmark, or tag
+* Add an RSVP rich text format for marking event responses as yes, no, maybe, or interested
+* Stop sending repeated Webmentions for posts that have not changed, and retry targets that failed during an earlier send
+* Guard the avatar lookup against a missing upload directory to stop `scandir` warnings from filling the logs, props @edent
+* Add JavaScript unit tests and a GitHub Actions workflow to run them
 
 ### 5.8.1
 

--- a/webmention.php
+++ b/webmention.php
@@ -5,7 +5,7 @@
  * Description: Webmention support for WordPress posts
  * Author: Matthias Pfefferle
  * Author URI: https://notiz.blog/
- * Version: 5.8.1
+ * Version: 5.9.0
  * Requires at least: 6.2
  * Requires PHP: 7.4
  * License: MIT
@@ -16,7 +16,7 @@
 
 namespace Webmention;
 
-\define( 'WEBMENTION_VERSION', '5.8.1' );
+\define( 'WEBMENTION_VERSION', '5.9.0' );
 
 \define( 'WEBMENTION_PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 \define( 'WEBMENTION_PLUGIN_BASENAME', \plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Version bump and changelog for 5.9.0.

* Add a reaction picker to the block editor link popover for marking a link as a reply, like, repost, bookmark, or tag
* Add an RSVP rich text format for marking event responses as yes, no, maybe, or interested
* Stop sending repeated Webmentions for posts that have not changed, and retry targets that failed during an earlier send
* Guard the avatar lookup against a missing upload directory to stop `scandir` warnings from filling the logs, props @edent
* Add JavaScript unit tests and a GitHub Actions workflow to run them