### PR TITLE
Fix the delete path for sources that are gone

### DIFF
--- a/includes/class-receiver.php
+++ b/includes/class-receiver.php
@@ -568,6 +568,15 @@ class Receiver {
 		$response = Request::get( $data['source'] );
 
 		if ( is_wp_error( $response ) ) {
+			// Pass the comment data along, so that handlers of `webmention_data_error`,
+			// like `self::delete()`, can find the comment the failed source belongs to.
+			$error_data = $response->get_error_data();
+			$error_data = is_array( $error_data ) ? $error_data : array();
+
+			$error_data['data'] = $data;
+
+			$response->add_data( $error_data );
+
 			return $response;
 		}
 
@@ -744,7 +753,7 @@ class Receiver {
 	}
 
 	/**
-	 * Delete comment if source returns error 410 or 452
+	 * Delete comment if source returns error 404, 410 or 451
 	 *
 	 * @param WP_Error $error
 	 */
@@ -766,7 +775,16 @@ class Receiver {
 			return;
 		}
 
-		$commentdata = $error->get_error_data();
+		$error_data = $error->get_error_data();
+
+		// The comment data is stored in the `data` key, but fall back to the error data
+		// itself for errors raised outside of `self::webmention_verify()`.
+		$commentdata = isset( $error_data['data'] ) ? $error_data['data'] : $error_data;
+
+		if ( ! is_array( $commentdata ) || empty( $commentdata['comment_meta']['webmention_source_url'] ) ) {
+			return;
+		}
+
 		$commentdata = self::check_dupes( $commentdata );
 
 		if ( isset( $commentdata['comment_ID'] ) ) {

--- a/includes/class-response.php
+++ b/includes/class-response.php
@@ -384,6 +384,10 @@ class Response {
 	/**
 	 * Get the HTTP Error if there is one
 	 *
+	 * Status codes that tell us the source is gone for good get a dedicated error code,
+	 * so that consumers like `Webmention\Receiver::delete()` can tell them apart from a
+	 * source that is only temporarily unavailable.
+	 *
 	 * @return WP_Error Returns a WP_Error object if the request fails; otherwise, returns false.
 	 */
 	public function get_error() {
@@ -391,11 +395,27 @@ class Response {
 			return false;
 		}
 
+		$code = $this->get_response_code();
+
+		/**
+		 * Filter the mapping of HTTP status codes to Webmention error codes.
+		 *
+		 * @param array $error_codes Map of HTTP status code to `WP_Error` code.
+		 */
+		$error_codes = apply_filters(
+			'webmention_http_error_codes',
+			array(
+				404 => 'resource_not_found',
+				410 => 'resource_deleted',
+				451 => 'resource_removed',
+			)
+		);
+
 		return new WP_Error(
-			'http_error',
+			isset( $error_codes[ $code ] ) ? $error_codes[ $code ] : 'http_error',
 			wp_remote_retrieve_response_message( $this->get_response() ),
 			array(
-				'status' => $this->get_response_code(),
+				'status' => $code,
 			)
 		);
 	}

--- a/tests/phpunit/tests/class-test-receiver.php
+++ b/tests/phpunit/tests/class-test-receiver.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Test Receiver class.
+ *
+ * @package Webmention
+ */
+
+use Webmention\Receiver;
+use Webmention\Response;
+
+/**
+ * Test Receiver class.
+ */
+class Test_Receiver extends WP_UnitTestCase {
+	/**
+	 * Source URL of the incoming Webmention.
+	 *
+	 * @var string
+	 */
+	const SOURCE = 'https://example.org/deleted-post/';
+
+	/**
+	 * Test post.
+	 *
+	 * @var WP_Post
+	 */
+	private $post;
+
+	/**
+	 * Set up test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->post = self::factory()->post->create_and_get();
+	}
+
+	/**
+	 * Build a mocked HTTP response.
+	 *
+	 * @param int    $code    HTTP status code.
+	 * @param string $message HTTP status message.
+	 *
+	 * @return array The mocked `wp_remote_get()` return value.
+	 */
+	private function http_response( $code, $message ) {
+		return array(
+			'headers'  => array(),
+			'response' => array(
+				'code'    => $code,
+				'message' => $message,
+			),
+			'body'     => '',
+		);
+	}
+
+	/**
+	 * Make every outgoing HTTP request return the given status code.
+	 *
+	 * @param int    $code    HTTP status code.
+	 * @param string $message HTTP status message.
+	 */
+	private function mock_http_status( $code, $message ) {
+		add_filter(
+			'pre_http_request',
+			function () use ( $code, $message ) {
+				return $this->http_response( $code, $message );
+			}
+		);
+	}
+
+	/**
+	 * Create a Webmention comment for the test post.
+	 *
+	 * @return int The comment ID.
+	 */
+	private function create_webmention_comment() {
+		return self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $this->post->ID,
+				'comment_type'    => WEBMENTION_COMMENT_TYPE,
+				'comment_meta'    => array(
+					'protocol'              => 'webmention',
+					'webmention_source_url' => self::SOURCE,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Send a Webmention for the test post.
+	 *
+	 * @return WP_REST_Response|WP_Error The result of the request.
+	 */
+	private function receive_webmention() {
+		$request = new WP_REST_Request( 'POST', '/webmention/1.0/endpoint' );
+		$request->set_param( 'source', self::SOURCE );
+		$request->set_param( 'target', get_permalink( $this->post ) );
+
+		return Receiver::post( $request );
+	}
+
+	/**
+	 * HTTP status codes that signal a removed source and the error codes they map to.
+	 *
+	 * @return array[]
+	 */
+	public function data_gone_status_codes() {
+		return array(
+			'not found'             => array( 404, 'Not Found', 'resource_not_found' ),
+			'gone'                  => array( 410, 'Gone', 'resource_deleted' ),
+			'unavailable for legal' => array( 451, 'Unavailable For Legal Reasons', 'resource_removed' ),
+		);
+	}
+
+	/**
+	 * A removed source has to produce an error code `Receiver::delete()` acts on.
+	 *
+	 * @dataProvider data_gone_status_codes
+	 *
+	 * @param int    $status   HTTP status code.
+	 * @param string $message  HTTP status message.
+	 * @param string $expected Expected `WP_Error` code.
+	 */
+	public function test_get_error_maps_status_to_error_code( $status, $message, $expected ) {
+		$response = new Response( self::SOURCE, $this->http_response( $status, $message ) );
+		$error    = $response->get_error();
+
+		$this->assertInstanceOf( 'WP_Error', $error );
+		$this->assertSame( $expected, $error->get_error_code() );
+		$this->assertSame( $status, $error->get_error_data()['status'] );
+	}
+
+	/**
+	 * Other HTTP errors stay generic.
+	 */
+	public function test_get_error_keeps_generic_code_for_other_errors() {
+		$response = new Response( self::SOURCE, $this->http_response( 500, 'Internal Server Error' ) );
+
+		$this->assertSame( 'http_error', $response->get_error()->get_error_code() );
+	}
+
+	/**
+	 * A Webmention for a source that is gone removes the stored comment.
+	 *
+	 * @dataProvider data_gone_status_codes
+	 *
+	 * @param int    $status  HTTP status code.
+	 * @param string $message HTTP status message.
+	 */
+	public function test_gone_source_deletes_comment( $status, $message ) {
+		$comment_id = $this->create_webmention_comment();
+
+		$this->mock_http_status( $status, $message );
+
+		$this->receive_webmention();
+
+		$comment = get_comment( $comment_id );
+
+		$this->assertTrue(
+			null === $comment || 'trash' === $comment->comment_approved,
+			'The comment should have been deleted or trashed.'
+		);
+	}
+
+	/**
+	 * A source that is only temporarily broken keeps the stored comment.
+	 */
+	public function test_server_error_keeps_comment() {
+		$comment_id = $this->create_webmention_comment();
+
+		$this->mock_http_status( 500, 'Internal Server Error' );
+
+		$this->receive_webmention();
+
+		$comment = get_comment( $comment_id );
+
+		$this->assertNotNull( $comment );
+		$this->assertNotSame( 'trash', $comment->comment_approved );
+	}
+}


### PR DESCRIPTION
Fixes #641.

The delete path could not fire. `Response::get_error()` always used the code `http_error`, so the codes `Receiver::delete()` looks for (`resource_not_found`, `resource_deleted`, `resource_removed`) were never produced anywhere in the plugin. And even with a matching code, the error data was only `array( 'status' => 410 )`, so `check_dupes()` had no source URL to find the comment with.

* `Response::get_error()` now maps 404, 410 and 451 to those three codes, everything else stays `http_error`. The map goes through a new `webmention_http_error_codes` filter.
* `webmention_verify()` attaches the comment data to the error, under a `data` key, so the `status` stays intact for the REST response.
* `delete()` reads the comment data from there and bails when there is no source URL, instead of handing junk to `check_dupes()`.

Tests for the mapping and for the whole path: receive a Webmention, re-send it with the source returning 404/410/451, the comment should be gone. A 500 has to leave it alone.

I did not touch the response itself, the request still errors out with a 410 after the delete. I think a delete should probably answer 200, but that is a different discussion.
