### PR TITLE
only load one stylesheet on the front end

### DIFF
--- a/assets/css/webmention.css
+++ b/assets/css/webmention.css
@@ -76,3 +76,10 @@
 	width: .75em;
 	height: 0;
 }
+
+/* RSVP Styles */
+data.p-rsvp {
+	text-decoration: underline dotted;
+	text-decoration-thickness: 2px;
+	text-underline-offset: 2px;
+}

--- a/build/rsvp/index-rtl.css
+++ b/build/rsvp/index-rtl.css
@@ -1,1 +1,1 @@
-.webmention-rsvp-popover .webmention-rsvp-popover__buttons{display:flex;gap:4px;padding:8px}data.p-rsvp{-webkit-text-decoration:underline dotted;text-decoration:underline dotted;text-decoration-thickness:2px;text-underline-offset:2px}
+.webmention-rsvp-popover .webmention-rsvp-popover__buttons{display:flex;gap:4px;padding:8px}

--- a/build/rsvp/index.asset.php
+++ b/build/rsvp/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react-jsx-runtime', 'wp-block-editor', 'wp-components', 'wp-element', 'wp-i18n', 'wp-primitives', 'wp-rich-text'), 'version' => 'a9a908f71f8cdf91de46');
+<?php return array('dependencies' => array('react-jsx-runtime', 'wp-block-editor', 'wp-components', 'wp-element', 'wp-i18n', 'wp-primitives', 'wp-rich-text'), 'version' => 'ba1f53d3d95138286ad8');

--- a/build/rsvp/index.css
+++ b/build/rsvp/index.css
@@ -1,1 +1,1 @@
-.webmention-rsvp-popover .webmention-rsvp-popover__buttons{display:flex;gap:4px;padding:8px}data.p-rsvp{-webkit-text-decoration:underline dotted;text-decoration:underline dotted;text-decoration-thickness:2px;text-underline-offset:2px}
+.webmention-rsvp-popover .webmention-rsvp-popover__buttons{display:flex;gap:4px;padding:8px}

--- a/includes/class-block.php
+++ b/includes/class-block.php
@@ -119,7 +119,7 @@ class Block {
 			'webmention',
 			WEBMENTION_PLUGIN_URL . 'assets/css/webmention.css',
 			array(),
-			\Webmention\version()
+			version()
 		);
 	}
 }

--- a/includes/class-block.php
+++ b/includes/class-block.php
@@ -84,40 +84,42 @@ class Block {
 			$asset_data['version'],
 			true
 		);
-	}
-
-	/**
-	 * Enqueue block assets for the RSVP format.
-	 *
-	 * The RSVP styles need to load both inside the editor iframe (to style the
-	 * `data.p-rsvp` elements while editing) and on the front end (to style the
-	 * same elements in published content). On the front end they are always
-	 * enqueued; in the admin editor they are limited to post types that support
-	 * Webmentions, matching the gate applied to the RSVP script.
-	 */
-	public static function enqueue_block_assets() {
-		if ( is_admin() ) {
-			$current_screen = \get_current_screen();
-			$post_types     = \get_post_types_by_support( 'webmentions' );
-
-			if ( ! $current_screen || ! in_array( $current_screen->post_type, $post_types, true ) ) {
-				return;
-			}
-		}
-
-		$asset_file = WEBMENTION_PLUGIN_DIR . 'build/rsvp/index.asset.php';
-
-		if ( ! file_exists( $asset_file ) ) {
-			return;
-		}
-
-		$asset_data = include $asset_file;
 
 		wp_enqueue_style(
 			'webmention-rsvp',
 			plugins_url( 'build/rsvp/index.css', WEBMENTION_PLUGIN_FILE ),
 			array(),
 			$asset_data['version']
+		);
+	}
+
+	/**
+	 * Enqueue the front end stylesheet inside the block editor iframe.
+	 *
+	 * `data.p-rsvp` markup lives in the post content, so it is styled by the
+	 * front end stylesheet rather than by an editor specific one. Loading that
+	 * same stylesheet inside the iframe keeps the editor in sync with the
+	 * published output and keeps the front end down to a single, dequeueable
+	 * `webmention` stylesheet.
+	 */
+	public static function enqueue_block_assets() {
+		// The front end enqueues this stylesheet itself, see Webmention::enqueue_scripts().
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		$current_screen = \get_current_screen();
+		$post_types     = \get_post_types_by_support( 'webmentions' );
+
+		if ( ! $current_screen || ! in_array( $current_screen->post_type, $post_types, true ) ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'webmention',
+			WEBMENTION_PLUGIN_URL . 'assets/css/webmention.css',
+			array(),
+			\Webmention\version()
 		);
 	}
 }

--- a/src/rsvp/editor.scss
+++ b/src/rsvp/editor.scss
@@ -1,5 +1,10 @@
 /**
  * RSVP Format - Editor Styles
+ *
+ * Only styles for the toolbar popover, which React renders into the main
+ * editor document. The `data.p-rsvp` markup itself lives inside the editor
+ * iframe and is styled by `assets/css/webmention.css`, the same stylesheet
+ * that styles it on the front end.
  */
 
 .webmention-rsvp-popover {
@@ -8,11 +13,4 @@
 		padding: 8px;
 		gap: 4px;
 	}
-}
-
-/* Style RSVP text in the editor */
-data.p-rsvp {
-	text-decoration: underline dotted;
-	text-decoration-thickness: 2px;
-	text-underline-offset: 2px;
 }


### PR DESCRIPTION
fix #652

`build/rsvp/index.css` was enqueued on every front end view, even on archives, while `webmention.css` only loads on singular pages. And most of that file was editor only anyway, the popover styles can never match anything on the front end.

So i moved the `data.p-rsvp` rule into `assets/css/webmention.css`, and the popover styles to where the popover actually renders. It is a `Popover` component, so it lives in the main editor document and not in the iframe, which means those flex rules were probably never applied before. `enqueue_block_assets` now loads `webmention.css` into the iframe instead, same hook and same post type gate as before, only a different file.

Front end before and after, checked on wp-env:

| | before | after |
|---|---|---|
| front page | `build/rsvp/index.css` | nothing |
| singular post | `webmention.css` + `build/rsvp/index.css` | `webmention.css` |

So `wp_dequeue_style( 'webmention' )` is enough again.

One trade-off: `webmention.css` is gated on `is_singular()`, so rsvp text is no longer underlined on archive pages that print the full post content. The alternative is loading ~1.5kb everywhere, which felt like the wrong direction for this issue, but i can drop the gate if you think it matters.

I could not click through the editor to verify the popover, so that part is worth a look before merging.
